### PR TITLE
docs(simple-english): correct vocabulary rules and add MCP tool guidance

### DIFF
--- a/skills/simple-english/SKILL.md
+++ b/skills/simple-english/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simple-english
-version: 1.0.0
+version: 1.1.0
 description: |
   Write or rewrite technical text with the rules of ASD-STE100 Simplified
   Technical English so it is clear, unambiguous, and free of AI slop. Use for
@@ -28,12 +28,14 @@ When asked to write or rewrite technical text:
 
 1. **Select the mode** (pragmatic or strict, below).
 2. **Classify each passage** as procedural or descriptive. Every other rule depends on this.
-3. **Fix your vocabulary before drafting.** Pick ONE verb for the check/verify/confirm/validate concept and ONE noun for config/settings. Use no other word for these concepts in the whole document.
+3. **Correct your vocabulary before drafting.** In strict mode, use `make sure that` for the check/verify/confirm/ensure concept — the dictionary rejects all four as verbs. In pragmatic mode, pick one and keep it. Pick ONE noun for config/settings (all are valid technical nouns — pick one and keep it). Use no other word for these concepts in the whole document.
 4. **Apply the rules** from the catalog below.
-5. **Run the self-check** before you deliver. This step is not optional.
+5. **Do the self-check** before you deliver. This step is not optional.
 6. **Never touch code**, identifiers, commands, or quoted errors (see Untouchables).
 
 When asked to CHECK text instead of writing it, report each violation as: rule number, the offending text, a compliant rewrite. Cite only rule numbers that exist in this file. Do not cite rule numbers from memory: the numbering is unintuitive and models invent it (tested — an agent without this file cited "Rule 3.1: short sentences"; the real Rule 3.1 is about verb forms).
+
+**If the `asdste100` MCP tool is available**, use it to look up any word whose status is not sure before you make a decision on it. Start the `asdste100_find` tool with the exact word. The tool gives the approved/rejected status, the part of speech, and the alternative. Do not guess — make sure it is in the word list.
 
 ## Two Modes
 
@@ -202,14 +204,16 @@ GR-6 for software docs: "e.g." → "for example", "i.e." → "that is", and dele
 
 The official dictionary (~900 approved words, ~1,200 banned words with alternatives) is copyrighted by ASD and is not reproduced here. Its mechanics apply without it: **one word, one meaning, one part of speech.**
 
+**If the `asdste100` MCP tool is available**, look up any word before ruling on it: `asdste100_find("word")`. The tool returns the exact dictionary status (approved/rejected), the approved part of speech, and the mandated alternative. Use it instead of relying on the examples below, which cover only a small sample.
+
 Known part-of-speech rulings, useful as patterns:
 
 | Word | Ruling |
 |---|---|
 | test, check, work | Noun only. "Do a test", not "test the pump". "Check that X" becomes "make sure that X". |
-| oil | Noun only as used in STE examples. For the verb, the dictionary gives "lubricate". |
+| oil | Technical noun (TN) only. For the verb, the dictionary gives "lubricate": "Lubricate the linkage with oil." |
 | help | Verb only. For the noun, the dictionary gives "aid": "with the aid of". |
-| fall | "To move down by gravity" only, never "decrease". |
+| fall (noun) | Rejected. Use "decrease" for a reduction in value. Use FALL (verb) only for physical movement downward by gravity: "Make sure that the tools do not fall into the engine." |
 | follow | "To come after" only, never "obey". Write "obey the instructions". |
 | above, below | Physical positions only. For limits write "more than", "less than". |
 
@@ -258,14 +262,27 @@ This table is ours, not the ASD dictionary. It maps the words AI-generated docs 
 
 ### Consistency pass
 
-Collapse these common rotations to one term each (Rules 1.11, 9.4):
+Collapse synonym rotations to one term each (Rules 1.11, 9.4). The two lists below work differently.
 
-- check / verify / confirm / validate / ensure → pick one
+**Technical nouns — not in the dictionary. Pick one and keep it consistent (both modes):**
+
 - config / configuration / settings / options → pick one
-- delete / remove / drop / destroy → one per meaning, kept consistent
-- error / issue / problem / failure → "error" for errors, "failure" for failed operations
-- run / execute / invoke / launch → pick one
-- show / display / render / present → pick one
+
+**Dictionary rulings — the standard has already chosen. Use the approved word (strict mode); pick one and keep it consistent (pragmatic mode):**
+
+| You wrote | Dictionary status | Use instead |
+|---|---|---|
+| check (verb) / verify / confirm / ensure | All rejected as verbs | `make sure that` (strict); pick one (pragmatic) |
+| validate | Not in dictionary | Use as technical verb (Rule 1.12), or replace with `make sure that` |
+| delete / drop (verb) / destroy | All rejected | `erase` (data), `remove` (physical); avoid `drop` and `destroy` |
+| remove | Approved verb | Keep it |
+| run / execute | Both rejected | `operate` (strict); pick one (pragmatic) |
+| invoke / launch | Not in dictionary | Use as technical verbs (Rule 1.12) |
+| display (verb) / render / present (verb) | All rejected | `show` (approved verb) |
+| issue | Not in dictionary | Use as technical noun, or replace with `problem` (approved) |
+| failure | Rejected in general use; approved as TN for performance loss | Use only when it means a performance error: "a failure of the pump" |
+| error | Approved noun | Keep it |
+| problem | Approved noun | Keep it |
 
 ## Untouchables
 

--- a/skills/simple-english/references/checklist.md
+++ b/skills/simple-english/references/checklist.md
@@ -39,5 +39,5 @@ Search the draft for each pattern. Every hit outside code blocks and quoted text
 
 ## When reporting violations (check mode)
 
-For each violation give: the rule number, the offending text, and a compliant rewrite. Cite only rule numbers that appear in rules.md.
+For each violation give: the rule number, the offending text, and a compliant rewrite. Cite only rule numbers that appear in SKILL.md.
 End the report with this statement when the user asked for STE compliance: "No tool can guarantee ASD-STE100 compliance. Final approval rests with the writer. The official standard is a free download at asd-ste100.org."


### PR DESCRIPTION
* Correct the check/verify/confirm/ensure ruling: reject all four as verbs and require `make sure that` in strict mode.
* Correct the `fall` ruling: reject the noun form and limit the verb to physical downward movement only.
* Correct the `oil` ruling: mark it as a technical noun (TN) only.
* Expand the synonym-rotation table with dictionary status and approved alternatives for delete, run, display, issue, failure, and error.
* Add instructions to use the `asdste100` MCP tool to look up any word whose status is not certain before making a decision on it.
* Correct the checklist reference from `rules.md` to `SKILL.md`.
* Increase the version from 1.0.0 to 1.1.0.

==========

I did a simple test to show the differences with and without the MCP invocation:

# Pragmatic

## Without asdste100-mcp

> Convert this sentence to simple english:
> Ensure the system behaves correctly.

**Make sure that the system works correctly.**

```
→Skill "simple-english"
Mode: Pragmatic
Classification: Procedural (it is an instruction — it tells the reader to do something)
Violations:
- "Ensure" is rejected as a verb. The replacement is make sure that.
- "the system" needs an article — it has one, so that is fine.
- "behaves correctly" is vague. STE asks for a specific, testable action. However, without more context, the meaning must be preserved.
Result:
Make sure that the system works correctly.
Self-check:
- 7 words — well under the 20-word procedural limit.
- No contractions, no -ing verbs, no semicolons, no banned modals.
- Condition before command: no condition present, so not applicable.
- "ensure" replaced with "make sure that" throughout.
```

## With asdste100-mcp

> Convert this sentence to simple english:
> Ensure the system behaves correctly. 

**Make sure that the system behaves correctly.**

```
→Skill "simple-english"
# asdste100_find [term=ensure]
{
  "name": "ensure",
  "status": "rejected",
…
Click to expand
Result:
Make sure that the system behaves correctly.
What changed:
- ensure is rejected by ASD-STE100. The approved alternative is make sure that.
```

# Strict

## Without asdste100-mcp

> Convert this sentence to strict simple english:
> Ensure the system behaves correctly.

→Skill "simple-english"
Strict mode applies here. The word "ensure" is rejected as a verb. The approved replacement is make sure that.
The sentence is procedural (an instruction), so the 20-word limit applies.
Before:
Ensure the system behaves correctly.
After:
Make sure that the system behaves correctly.
What changed:
- ensure (rejected verb) → make sure that (approved form, Rule 1.3)
- All other words are within limits; sentence is 8 words, well under the 20-word procedural limit (Rule 5.1)

## With asdste100-mcp

> Convert this sentence to strict simple english:
> Ensure the system behaves correctly. 

**Make sure that the system operates correctly.**

```
→Skill "simple-english"
First, I will look up "ensure" in the STE vocabulary to confirm its status.
# asdste100_find [term=ensure]
{
  "name": "ensure",
  "status": "rejected",
…
Click to expand
Now I will look up "behave" to check its status.
# asdste100_find [term=behave]
{"result":[]}
# asdste100_find [term=correctly]
{
  "name": "CORRECTLY",
  "status": "approved",
…
Click to expand
"Behave" is not in the STE dictionary. It is a domain verb (Rule 1.12), so it can be used as a technical verb. However, "behave correctly" is vague — STE prefers concrete, specific language. The sentence also uses "ensure" (rejected) and is a procedural instruction.
Analysis:
- ensure — rejected verb; replace with MAKE SURE THAT
- behaves correctly — vague; STE prefers a specific, testable statement. However, if no more specific meaning is available, "operates correctly" or "works correctly" can be used. Let me check "operate" and "work".
# asdste100_find [term=operate]
{
  "name": "OPERATE",
  "status": "approved",
…
Click to expand
# asdste100_find [term=work]
{
  "name": "WORK",
  "status": "approved",
…
Click to expand
work is rejected as a verb. operate is approved as a verb and fits well.
Result:
Original	Issue
Ensure	Rejected verb
behaves correctly	behave not in dictionary; work rejected as verb
Strict STE rewrite:
Make sure that the system operates correctly.
Self-check:
- Word count: 8 words — within the 20-word procedural limit (Rule 5.1)
- Imperative form (Rule 5.3)
- No contractions, no semicolons, no banned modals
- ensure replaced with make sure that (dictionary ruling)
- correctly is approved (adverb)
- operate is approved (verb)
```
