### PR TITLE
Add Claude Code plugin marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "simple-english",
+  "owner": {
+    "name": "AminBlg",
+    "url": "https://github.com/AminBlg"
+  },
+  "description": "ASD-STE100 Simplified Technical English skill for clear, unambiguous technical writing.",
+  "plugins": [
+    {
+      "name": "simple-english",
+      "source": "./",
+      "displayName": "Simple English",
+      "description": "Write or rewrite technical text with ASD-STE100 Simplified Technical English: short sentences, one word one meaning, active voice, condition before command.",
+      "version": "1.0.0",
+      "author": {
+        "name": "AminBlg"
+      },
+      "homepage": "https://github.com/AminBlg/SimpleEnglish",
+      "repository": "https://github.com/AminBlg/SimpleEnglish",
+      "license": "MIT",
+      "keywords": ["technical-writing", "documentation", "ste", "asd-ste100"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-english",
+  "displayName": "Simple English",
+  "description": "Write or rewrite technical text with ASD-STE100 Simplified Technical English: short sentences, one word one meaning, active voice, condition before command.",
+  "version": "1.0.0",
+  "author": {
+    "name": "AminBlg"
+  },
+  "homepage": "https://github.com/AminBlg/SimpleEnglish",
+  "repository": "https://github.com/AminBlg/SimpleEnglish",
+  "license": "MIT",
+  "keywords": ["technical-writing", "documentation", "ste", "asd-ste100"]
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ That is it. The [skills CLI](https://github.com/vercel-labs/skills) detects your
 npx skills use AminBlg/SimpleEnglish@simple-english
 ```
 
+**Claude Code plugin**: this repo is also a plugin marketplace. Run:
+
+```
+/plugin marketplace add AminBlg/SimpleEnglish
+/plugin install simple-english@simple-english
+```
+
 No SKILL.md support at all? Paste [`prompts/system-prompt.md`](prompts/system-prompt.md) into your system prompt, AGENTS.md, or `.cursorrules`. There is even a ~60-token version for tight budgets.
 
 Then ask for any technical writing, or say: *"rewrite this with simple-english"*.


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` at the repo root, turning this repo into a Claude Code plugin marketplace. The plugin's source is the marketplace root itself (`"source": "./"`), so it reuses the existing `skills/simple-english/` directory as-is via Claude Code's default skill-directory scan — no files were moved or duplicated.
- Adds a "Claude Code plugin" install snippet to the README alongside the existing `npx skills` instructions.

Verified locally with the `claude` CLI:
- `claude plugin validate .` passes
- `claude plugin marketplace add ./` and `claude plugin install simple-english@simple-english` succeed from a local path
- `claude plugin details simple-english@simple-english` confirms the plugin discovers exactly the one `simple-english` skill

## Test plan
- [ ] `/plugin marketplace add AminBlg/SimpleEnglish` in Claude Code
- [ ] `/plugin install simple-english@simple-english`
- [ ] Confirm the skill triggers as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)