### PR TITLE
Add Pi benchmark runner and four-model results

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,22 @@ Where it refuses to go: marketing copy, blog voice, brand writing. Flat on purpo
 | claude-sonnet-5 | 2.67 | 0.53 | 80% |
 | claude-sonnet-4-6 | 2.06 | 0.52 | 75% |
 
-Output tokens went DOWN on all six models too (the skill writes shorter). Deterministic regex linter, same rules for both conditions, honest-caveat list and full method in [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` — needs only a logged-in Claude Code CLI.
+Output tokens went DOWN on all six Claude models too. Deterministic regex linter, same rules for both conditions, honest-caveat list and full method in [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` — needs only a logged-in Claude Code CLI.
+
+### Pi cross-check
+
+A separate Pi run tested four models on the same 8 tasks and 2 conditions. All 64 generations completed.
+
+| Model | Baseline viol/100w | Skill viol/100w | Reduction |
+|---|---:|---:|---:|
+| GLM-5.2 max | 2.56 | 0.40 | 84.4% |
+| GPT-5.6 Sol medium | 1.33 | 0.16 | 88.0% |
+| GPT-5.6 Terra medium | 1.69 | 0.48 | 71.6% |
+| GPT-5.6 Luna medium | 1.28 | 0.42 | 67.2% |
+
+The skill reduced measured violations on all four models. It shortened final text only on GLM-5.2; the three GPT-5.6 models wrote slightly more words.
+
+See the [Pi results, method, raw responses, and reproduction command](evals/results/pi-2026-07-31/RESULTS.md). Run other configured models with `python3 evals/run_pi_bench.py --model PROVIDER/MODEL:THINKING`.
 
 ## 🧾 Receipts
 

--- a/evals/results/pi-2026-07-31/RESULTS.md
+++ b/evals/results/pi-2026-07-31/RESULTS.md
@@ -1,0 +1,45 @@
+# Pi benchmark results
+
+**The skill reduced mean linter violations by 67.2% to 88.0% across 4 models.**
+
+This run contains 64 generations: 4 models x 8 scenarios x 2 conditions.
+
+| Model | Baseline viol/100w | Skill viol/100w | Reduction | Final words (base -> skill) | Scenarios (better/tied/worse) | Cost |
+|---|---:|---:|---:|---:|---:|---:|
+| `zai/glm-5.2:max` | 2.56 | 0.40 | 84.4% | 95.0 -> 86.6 | 6/2/0 | $0.000000 |
+| `openai-codex/gpt-5.6-sol:medium` | 1.33 | 0.16 | 88.0% | 89.5 -> 100.5 | 5/3/0 | $0.534910 |
+| `openai-codex/gpt-5.6-terra:medium` | 1.69 | 0.48 | 71.6% | 76.0 -> 78.6 | 4/3/1 | $0.156424 |
+| `openai-codex/gpt-5.6-luna:medium` | 1.28 | 0.42 | 67.2% | 88.2 -> 96.2 | 5/2/1 | $0.016152 |
+
+## Method
+
+The runner used the same scenarios, skill prompt, linter, and per-scenario averaging as `run_bench.py`.
+It sent only the scenario prompt for the baseline condition.
+It added the complete `SKILL.md` text for the skill condition.
+Both conditions used this neutral system prompt: `Return only the final text requested by the user.`
+
+Pi tools, skills, prompt templates, extensions, context files, and session persistence were disabled.
+The runner made one generation for each matrix cell and did not run a judge pass.
+
+## Reproduce
+
+```bash
+python3 evals/run_pi_bench.py \
+  --results-dir evals/results/pi-2026-07-31 \
+  --model zai/glm-5.2:max \
+  --model openai-codex/gpt-5.6-sol:medium \
+  --model openai-codex/gpt-5.6-terra:medium \
+  --model openai-codex/gpt-5.6-luna:medium
+```
+
+Delete `raw/` first to replace the committed generations. Existing raw files are skipped.
+
+## Caveats
+
+- The regex linter undercounts some violations and reports some false positives.
+  For example, it treats descriptive sentences with a non-leading `when` clause as trailing conditions.
+- One generation per cell does not measure model variance.
+- Provider output-token counts can include hidden reasoning tokens.
+  The table reports final-text word counts instead.
+- Costs are provider-reported estimates, not billing records.
+- The run measures the linter score, not ASD-STE100 certification or overall writing quality.

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a streaming data pipeline that exports PostgreSQL tables to Amazon S3 as Parquet. A reader process maintains a database connection, executes the export query, and fetches rows in bounded batches to avoid exhausting memory. Each batch is passed to a converter, which applies schema-aware type mapping, encodes column data, and assembles Parquet row groups with configurable compression and sizing. Completed row-group data flows to an uploader, which creates S3 multipart uploads, sends parts concurrently or sequentially, and retries transient failures with exponential backoff. Bounded queues between stages provide backpressure, ensuring the reader does not outrun conversion or network throughput. Progress, row counts, and failures are logged, while upload state can be checkpointed so interrupted jobs resume safely or cleanly abort incomplete multipart objects.",
+  "input_tokens": 76,
+  "output_tokens": 204,
+  "reasoning_tokens": 37,
+  "total_tokens": 280,
+  "cost_usd": 0.00026,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 7512,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 125,
+    "sentences": 6,
+    "mean_sentence_words": 20.8,
+    "longest_sentence_words": 25,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.8
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "I\u2019m sorry, but I don\u2019t know the exact error message text.",
+  "input_tokens": 67,
+  "output_tokens": 45,
+  "reasoning_tokens": 24,
+  "total_tokens": 112,
+  "cost_usd": 6.74e-05,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 4486,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting started\n\nInstall SQLPipe with the official installer:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nVerify that the command is available:\n\n```sh\nsqlpipe --help\n```\n\nNext, create a `sqlpipe.yaml` file in your project directory. Define your source, destination, and pipeline options. For example:\n\n```yaml\nsource:\n  type: postgres\n  connection: ${SOURCE_DATABASE_URL}\n\ndestination:\n  type: warehouse\n  connection: ${DESTINATION_DATABASE_URL}\n\npipeline:\n  include:\n    - public.customers\n    - public.orders\n```\n\nKeep credentials out of the configuration file by referencing environment variables, as shown above. Export those variables in your shell or load them through your preferred secret manager.\n\nRun your first pipeline with:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nSQLPipe reads the configuration, connects to the specified systems, and executes the pipeline. Use `sqlpipe run --help` to review available options, and check the command output for progress, warnings, and errors. Adjust `sqlpipe.yaml` as needed, then rerun the command.",
+  "input_tokens": 85,
+  "output_tokens": 276,
+  "reasoning_tokens": 34,
+  "total_tokens": 361,
+  "cost_usd": 0.00034819999999999995,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 8693,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 100,
+    "sentences": 11,
+    "mean_sentence_words": 9.1,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 1,
+    "violations_per_100w": 1.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "Between 14:02 and 14:31 UTC, approximately 12% of API requests returned HTTP 502 errors. The incident was caused by a deployment that unintentionally removed the cache warmup step, resulting in elevated load on backend services and intermittent request failures. We identified the issue and reverted the deployment at 14:27 UTC. Error rates began recovering immediately, and service was fully restored by 14:31 UTC. We are reviewing deployment safeguards and adding checks to ensure required cache warmup steps are preserved in future releases. We apologize for the disruption and appreciate your patience.",
+  "input_tokens": 87,
+  "output_tokens": 162,
+  "reasoning_tokens": 38,
+  "total_tokens": 249,
+  "cost_usd": 0.0002118,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 6815,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 91,
+    "sentences": 6,
+    "mean_sentence_words": 15.2,
+    "longest_sentence_words": 25,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.2
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a command-line tool for moving data from PostgreSQL tables to Amazon S3 object storage as Parquet files. It is designed for reliable exports that fit into analytics pipelines, data lakes, and backups. With configuration, sqlpipe connects to your database, reads tables or queries, and writes partitioned output to S3 while keeping your schema and type information intact.\n\nUse sqlpipe for repeatable, incremental-friendly table synchronization without building custom scripts or managing temporary files. It supports practical controls for credentials, concurrency, filtering, and output layout, making it suitable for local workflows and production jobs alike. Parquet output can be consumed by engines such as Spark, DuckDB, Athena, and other tools across the modern data stack.",
+  "input_tokens": 70,
+  "output_tokens": 759,
+  "reasoning_tokens": 606,
+  "total_tokens": 829,
+  "cost_usd": 0.0009247999999999999,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 17134,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 115,
+    "sentences": 6,
+    "mean_sentence_words": 19.2,
+    "longest_sentence_words": 25,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.87
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe v2.0\n\nsqlpipe v2.0 introduces a breaking API change, a new incremental processing option, and faster Parquet output.\n\n## Breaking change: `/v2/users`\n\nThe `name` field has been replaced with two fields:\n\n- `first_name`\n- `last_name`\n\nUpdate clients, schemas, and downstream transformations that reference `name`. Existing integrations may fail until they adopt the new response format.\n\n## Incremental processing\n\nUse the new `--incremental` flag to process only records added or changed since the previous run. This can reduce processing time and resource usage for recurring pipelines.\n\n```bash\nsqlpipe export --incremental\n```\n\n## Faster Parquet writes\n\nParquet output is now approximately 40% faster, improving throughput for large exports and reducing pipeline completion times.\n\nReview your API mappings and deployment scripts before upgrading to ensure compatibility with the new user schema and command-line options.",
+  "input_tokens": 89,
+  "output_tokens": 219,
+  "reasoning_tokens": 25,
+  "total_tokens": 308,
+  "cost_usd": 0.0002806,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 7778,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 114,
+    "sentences": 8,
+    "mean_sentence_words": 14.0,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 1,
+      "perfect_tense": 1,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.63
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Verify the backup exists before migrating.",
+  "input_tokens": 54,
+  "output_tokens": 11,
+  "reasoning_tokens": 0,
+  "total_tokens": 65,
+  "cost_usd": 2.4e-05,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 4101,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 6,
+    "sentences": 1,
+    "mean_sentence_words": 6.0,
+    "longest_sentence_words": 6,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__baseline__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nVerify that the hostname, port, database name, and credentials supplied to `sqlpipe` are correct. Confirm Postgres is running and accepting TCP connections, then test reachability from the same machine:\n\n```bash\nnc -vz <host> 5432\n```\n\nCheck firewall rules, security groups, VPN access, and `pg_hba.conf`. If Postgres is private, run `sqlpipe` from an approved network or use the required tunnel. DNS failures may indicate an incorrect hostname or unavailable resolver. Increase the connection timeout only after network access is confirmed, and review `sqlpipe` logs for TLS or authentication errors.\n\n### S3 permission errors\n\nConfirm the bucket and region, and ensure the configured AWS identity is the one intended:\n\n```bash\naws sts get-caller-identity\naws s3 ls s3://<bucket>/<prefix>\n```\n\nThe identity typically needs permission to list the bucket and read or write objects, including multipart-upload actions for large files. Check IAM policies, bucket policies, encryption-key permissions, and any organization or VPC endpoint restrictions. Ensure the object prefix is correct and that credentials have not expired.",
+  "input_tokens": 59,
+  "output_tokens": 292,
+  "reasoning_tokens": 43,
+  "total_tokens": 351,
+  "cost_usd": 0.0003622,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 9049,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 144,
+    "sentences": 10,
+    "mean_sentence_words": 14.4,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 3
+    },
+    "violations_total": 4,
+    "violations_per_100w": 2.78
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a data pipeline that moves rows from Postgres to S3. It has three main components: a reader process, a converter, and an uploader. The reader process streams rows from Postgres in batches. It sends each batch to the converter. The converter turns each batch into a Parquet row group. It sends each row group to the uploader. The uploader writes multipart objects to S3. It retries failed writes to S3. The reader and converter stages preserve the batch flow. The uploader receives completed row groups and assigns them to object parts. Each object contains data from one or more Parquet row groups. The stages separate source reading, format conversion, and object storage. This separation lets the uploader retry an S3 write without a new read from Postgres.",
+  "input_tokens": 4746,
+  "output_tokens": 1422,
+  "reasoning_tokens": 1259,
+  "total_tokens": 6168,
+  "cost_usd": 0.0026556,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 29258,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 129,
+    "sentences": 14,
+    "mean_sentence_words": 9.2,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe: S3 upload failed: AccessDenied\nThe IAM credentials lack the `s3:PutObject` permission.\nGrant this permission for the target bucket and object path.",
+  "input_tokens": 4737,
+  "output_tokens": 176,
+  "reasoning_tokens": 134,
+  "total_tokens": 4913,
+  "cost_usd": 0.0011586,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 6981,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 22,
+    "sentences": 3,
+    "mean_sentence_words": 7.0,
+    "longest_sentence_words": 10,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting started\n\nInstall `sqlpipe` with the installation command:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nCreate a file named `sqlpipe.yaml` in your project directory.\n\nAdd the source and destination details that `sqlpipe` requires.\n\nSave the file after you add the configuration.\n\nIf you store the file in another directory, use its path in the command.\n\nRun the first data transfer:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nThe `--config` option tells `sqlpipe` to read the configuration from `sqlpipe.yaml`.\n\nIf the command reports an error, read the error message.\n\nMake sure that the source and destination details match your environment.\n\nMake sure that the database credentials allow the required connections.\n\nKeep `sqlpipe.yaml` out of public repositories when it contains credentials.\n\nAdd the file to `.gitignore` if it contains passwords or access tokens.\n\nRun the command again after you correct the configuration.\n\nUse the same configuration file for later runs when the source and destination do not change.",
+  "input_tokens": 4755,
+  "output_tokens": 523,
+  "reasoning_tokens": 299,
+  "total_tokens": 5278,
+  "cost_usd": 0.0015786,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 13230,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 141,
+    "sentences": 14,
+    "mean_sentence_words": 10.1,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 3,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.13
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "**Resolved: API request failures**\n\nBetween 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502 errors. The incident started after a deploy removed the cache warmup step. Without this step, some requests reached unavailable cache data and returned errors.\n\nThe team identified the deploy as the cause and reverted it at 14:27 UTC. Error rates decreased after the revert and returned to normal by 14:31 UTC. The team restored the cache warmup step and reviewed the deploy process. We apologize for the disruption.",
+  "input_tokens": 4757,
+  "output_tokens": 338,
+  "reasoning_tokens": 218,
+  "total_tokens": 5095,
+  "cost_usd": 0.0013570000000000001,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 9523,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 85,
+    "sentences": 7,
+    "mean_sentence_words": 12.0,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a command-line tool that syncs Postgres tables to Amazon S3 as Parquet files. It reads table data from Postgres and writes files to an S3 bucket. It preserves column values in a format that works with many data tools. Use sqlpipe for data transfer, backups, analytics, and scheduled exports. It does not require a separate application or graphical interface.\n\nThe tool can process selected tables and write output for downstream systems. A command-line interface makes sqlpipe suitable for local work, scripts, and automated jobs. You can run it from a workstation or a service that can reach both systems. This README explains installation, connection requirements, commands, and common workflows. Start with the quickstart to create a first export.",
+  "input_tokens": 4740,
+  "output_tokens": 1045,
+  "reasoning_tokens": 889,
+  "total_tokens": 5785,
+  "cost_usd": 0.002202,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 22464,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 120,
+    "sentences": 10,
+    "mean_sentence_words": 12.0,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "## sqlpipe v2.0\n\n### Breaking change\n\nThe `/v2/users` response no longer includes `name`. It now returns `first_name` and `last_name`.\n\nUpdate clients before you upgrade to v2.0.\n\nIf your client reads `name`, change it to read both new fields.\n\nIf your client sends `name`, send `first_name` and `last_name` instead.\n\nTest the updated client against v2.0 before production deployment.\n\n### New flag\n\nUse `--incremental` to process only new or changed records.\n\nIf you omit this flag, sqlpipe uses the full processing mode.\n\n### Performance\n\nsqlpipe writes Parquet data 40% faster in the v2.0 benchmark.\n\nActual speed depends on data size, storage, and system load.",
+  "input_tokens": 4759,
+  "output_tokens": 683,
+  "reasoning_tokens": 516,
+  "total_tokens": 5442,
+  "cost_usd": 0.0017714,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 15774,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 95,
+    "sentences": 10,
+    "mean_sentence_words": 9.5,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Before you run the migration, make sure that the backup exists.",
+  "input_tokens": 4724,
+  "output_tokens": 104,
+  "reasoning_tokens": 85,
+  "total_tokens": 4828,
+  "cost_usd": 0.0010696,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 5508,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-luna_medium__skill__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n### Connection timeouts to Postgres\n\nsqlpipe reports `dial tcp: i/o timeout` when it cannot connect to the Postgres server.\n\n1. Make sure that the host running sqlpipe can reach the Postgres port.\n2. If the server uses a firewall, allow traffic from the sqlpipe host.\n3. If the server uses a private network, connect sqlpipe to that network.\n4. If the network is slow, increase `source.connect_timeout_seconds` in the configuration.\n5. If the timeout continues, read the server address and port in the sqlpipe log.\n\n### S3 permission errors\n\nsqlpipe reports an S3 permission error when AWS rejects an operation.\n\n1. Make sure that the AWS credentials belong to the correct account.\n2. Make sure that the IAM policy allows access to the bucket and object path.\n3. If sqlpipe reads data, allow `s3:GetObject`.\n4. If sqlpipe writes data, allow `s3:PutObject`.\n5. If sqlpipe lists objects, allow `s3:ListBucket` on the bucket.\n6. If the bucket uses encryption, allow access to the required KMS key.\n7. If the error continues, read the AWS error message in the sqlpipe log.",
+  "input_tokens": 4729,
+  "output_tokens": 779,
+  "reasoning_tokens": 514,
+  "total_tokens": 5508,
+  "cost_usd": 0.0018806,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-luna",
+  "stop_reason": "stop",
+  "duration_ms": 17756,
+  "model": "openai-codex/gpt-5.6-luna:medium",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 167,
+    "sentences": 14,
+    "mean_sentence_words": 11.1,
+    "longest_sentence_words": 14,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.2
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is organized as a three-stage streaming pipeline that moves data from PostgreSQL to durable Parquet objects in S3. A reader process executes the source query and fetches rows in bounded batches, coordinating backpressure so memory use remains predictable. Each batch is passed to a converter, which maps PostgreSQL types to the target schema, encodes columns, and accumulates records into Parquet row groups. Completed row groups flow to an uploader that streams them into an S3 multipart upload, avoiding local staging and supporting large outputs. The uploader retries failed parts with bounded backoff, preserves part ordering, and completes the object only after all parts are acknowledged. Stage boundaries isolate database reads, CPU-intensive encoding, and network I/O, enabling independent tuning, concurrency, observability, cancellation, and recovery while maintaining end-to-end flow control.",
+  "input_tokens": 76,
+  "output_tokens": 533,
+  "reasoning_tokens": 360,
+  "total_tokens": 609,
+  "cost_usd": 0.01637,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 16667,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 129,
+    "sentences": 6,
+    "mean_sentence_words": 21.5,
+    "longest_sentence_words": 24,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.78
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "error uploading file to S3: AccessDenied: Access Denied\n\tstatus code: 403, request id: <request-id>, host id: <host-id>",
+  "input_tokens": 67,
+  "output_tokens": 1100,
+  "reasoning_tokens": 1060,
+  "total_tokens": 1167,
+  "cost_usd": 0.033335000000000004,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 34673,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 17,
+    "sentences": 4,
+    "mean_sentence_words": 3.8,
+    "longest_sentence_words": 5,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting started\n\nInstall `sqlpipe` using the official installation script:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nAfter installation, verify that the CLI is available:\n\n```sh\nsqlpipe --help\n```\n\nNext, create a `sqlpipe.yaml` file in your project directory. Define the source, destination, and pipeline settings required for your data workflow. For example:\n\n```yaml\nsource:\n  type: postgres\n  connection: ${SOURCE_DATABASE_URL}\n\ndestination:\n  type: postgres\n  connection: ${DESTINATION_DATABASE_URL}\n\npipeline:\n  table: public.customers\n```\n\nSet any referenced environment variables before running the pipeline:\n\n```sh\nexport SOURCE_DATABASE_URL=\"postgres://user:password@localhost/source\"\nexport DESTINATION_DATABASE_URL=\"postgres://user:password@localhost/destination\"\n```\n\nStart your first run with:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\n`sqlpipe` will load the configuration, connect to the configured systems, and execute the pipeline. Check the command output for progress, completion details, or configuration errors. Avoid committing credentials to version control; use environment variables or your preferred secrets manager instead.",
+  "input_tokens": 85,
+  "output_tokens": 393,
+  "reasoning_tokens": 140,
+  "total_tokens": 478,
+  "cost_usd": 0.012215,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 13608,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 92,
+    "sentences": 10,
+    "mean_sentence_words": 9.2,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 1,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 2
+    },
+    "violations_total": 3,
+    "violations_per_100w": 3.26
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "Resolved: Elevated API 502 Errors\n\nBetween 14:02 and 14:31 UTC, approximately 12% of API requests failed with HTTP 502 errors. The incident began after a deployment unintentionally removed the cache warmup step, causing increased load on backend services and resulting in failed requests.\n\nWe identified the deployment as the cause and reverted it at 14:27 UTC. Error rates returned to normal by 14:31 UTC.\n\nWe have restored the cache warmup step and are adding deployment safeguards and monitoring to prevent similar regressions. We apologize for the disruption and appreciate your patience while we resolved the issue.",
+  "input_tokens": 87,
+  "output_tokens": 214,
+  "reasoning_tokens": 82,
+  "total_tokens": 301,
+  "cost_usd": 0.006855,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 9669,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 96,
+    "sentences": 6,
+    "mean_sentence_words": 15.8,
+    "longest_sentence_words": 23,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.08
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a command-line tool for syncing PostgreSQL tables to Amazon S3 as Parquet files. It turns relational data into a compact, columnar format that is easy to store, query, and integrate with modern analytics workflows. Use it to export application data, build lightweight data pipelines, create durable snapshots, or prepare datasets for tools that read Parquet directly.\n\nDesigned for scripts, scheduled jobs, and CI/CD environments, sqlpipe keeps database-to-object-storage workflows simple and repeatable. Point it at a Postgres database, select the tables you need, and write the results to an S3 destination without building a custom exporter. Whether you are moving a single table or maintaining a broader data lake, sqlpipe provides a straightforward CLI for getting PostgreSQL data into S3.",
+  "input_tokens": 70,
+  "output_tokens": 237,
+  "reasoning_tokens": 74,
+  "total_tokens": 307,
+  "cost_usd": 0.00746,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 12309,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 121,
+    "sentences": 6,
+    "mean_sentence_words": 20.2,
+    "longest_sentence_words": 24,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe v2.0\n\nsqlpipe v2.0 introduces API improvements, incremental processing, and major performance gains.\n\n## Breaking change\n\nThe `/v2/users` response no longer includes the `name` field. It has been replaced by separate `first_name` and `last_name` fields for more consistent user data handling. Update integrations, schemas, and queries that depend on `name` before upgrading.\n\n## New: Incremental processing\n\nA new `--incremental` flag processes only new or changed records, reducing unnecessary work in recurring pipelines and making scheduled syncs faster and more efficient.\n\n```bash\nsqlpipe run --incremental\n```\n\n## Faster Parquet writes\n\nParquet output is now up to 40% faster through improvements to buffering and serialization. No configuration changes are required to benefit from the performance upgrade.",
+  "input_tokens": 89,
+  "output_tokens": 206,
+  "reasoning_tokens": 29,
+  "total_tokens": 295,
+  "cost_usd": 0.006625,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 10315,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 96,
+    "sentences": 7,
+    "mean_sentence_words": 13.7,
+    "longest_sentence_words": 24,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.08
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Verify backup before migration.",
+  "input_tokens": 54,
+  "output_tokens": 9,
+  "reasoning_tokens": 0,
+  "total_tokens": 63,
+  "cost_usd": 0.00054,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 5405,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 4,
+    "sentences": 1,
+    "mean_sentence_words": 4.0,
+    "longest_sentence_words": 4,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__baseline__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nIf `sqlpipe` times out while connecting to Postgres:\n\n- Confirm the hostname, port, database, and credentials in your connection string.\n- Verify that Postgres is running and accepting remote connections.\n- Test network access with `nc -vz <host> 5432` or connect using `psql`.\n- Check firewalls, VPNs, security groups, and Kubernetes network policies.\n- Ensure `pg_hba.conf` permits the client address and `listen_addresses` includes the required interface.\n- If SSL is required, verify the SSL mode and certificate paths.\n- Increase the connection timeout only after ruling out network or configuration issues.\n\n### S3 permission errors\n\nFor `AccessDenied`, `403`, or upload failures:\n\n- Confirm the active identity with `aws sts get-caller-identity`.\n- Verify the bucket name, region, and object prefix.\n- Ensure the IAM identity allows required actions such as `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket`.\n- Review bucket policies, permission boundaries, and organization service control policies.\n- For encrypted buckets, grant access to the relevant KMS key.\n- Check whether temporary AWS credentials have expired.",
+  "input_tokens": 59,
+  "output_tokens": 344,
+  "reasoning_tokens": 84,
+  "total_tokens": 403,
+  "cost_usd": 0.010615000000000001,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 15007,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 161,
+    "sentences": 15,
+    "mean_sentence_words": 9.9,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 3
+    },
+    "violations_total": 4,
+    "violations_per_100w": 2.48
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "# Architecture Overview\n\nsqlpipe uses a three-stage pipeline to move data from Postgres to S3. The stages are a reader process, a converter, and an uploader.\n\nThe reader process opens a Postgres connection and reads rows in batches. It streams each batch to the converter. It does not collect the complete result set before conversion. This flow limits the amount of source data that sqlpipe holds at one time.\n\nThe converter changes each batch into Parquet data. It organizes the rows into Parquet row groups and passes the converted data to the uploader. The Parquet format preserves the column structure for storage and later queries.\n\nThe uploader sends the Parquet data to S3 as multipart objects. It retries failed part uploads after temporary transfer errors. After all parts arrive, the uploader completes the object in S3.",
+  "input_tokens": 4746,
+  "output_tokens": 1508,
+  "reasoning_tokens": 1338,
+  "total_tokens": 6254,
+  "cost_usd": 0.06897,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 42919,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 133,
+    "sentences": 12,
+    "mean_sentence_words": 11.1,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "S3 upload failed: AccessDenied.\nThe IAM credentials do not have the s3:PutObject permission.\nAdd s3:PutObject to the IAM policy.\nUpload the object again.",
+  "input_tokens": 4737,
+  "output_tokens": 254,
+  "reasoning_tokens": 210,
+  "total_tokens": 4991,
+  "cost_usd": 0.031305,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 11563,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 23,
+    "sentences": 4,
+    "mean_sentence_words": 5.5,
+    "longest_sentence_words": 9,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "# Getting started\n\n## 1. Install sqlpipe\n\nOpen a terminal on the computer that will run sqlpipe.\n\nRun the installation command:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nWait until the installation is complete.\n\nMake sure that the `sqlpipe` command is available:\n\n```sh\nsqlpipe --version\n```\n\nIf your shell cannot find `sqlpipe`, open a new terminal. Then run `sqlpipe --version` again.\n\n## 2. Configure sqlpipe\n\nCreate a file named `sqlpipe.yaml` in your project directory.\n\nAdd the source connection, destination connection, and pipeline parameters for your environment.\n\nUse spaces for YAML indentation. Do not use tab characters.\n\nStore required credentials according to the security rules for your organization.\n\nMake sure that the file contains valid YAML. Save the file before you run sqlpipe.\n\n## 3. Run your first pipeline\n\nChange to the directory that contains `sqlpipe.yaml`.\n\nRun this command:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nRead the terminal output for the pipeline status.\n\nIf sqlpipe reports a configuration error, correct the value in `sqlpipe.yaml`. Then run the command again.\n\nIf the pipeline completes without an error, keep `sqlpipe.yaml` for later runs.",
+  "input_tokens": 4755,
+  "output_tokens": 1967,
+  "reasoning_tokens": 1694,
+  "total_tokens": 6722,
+  "cost_usd": 0.082785,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 48362,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 148,
+    "sentences": 19,
+    "mean_sentence_words": 7.8,
+    "longest_sentence_words": 12,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "API Request Failures\n\nBetween 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502 responses. A deployment removed the cache warmup step. As a result, the API servers received traffic before their caches were ready.\n\nWe identified the deployment as the cause and reverted it at 14:27 UTC. The error rate then decreased to its normal level. By 14:31 UTC, API request success rates returned to normal.\n\nWe monitored the API after the recovery and found no additional failures. We restored the cache warmup step in the deployment process. We also added a release check to prevent this error.",
+  "input_tokens": 917,
+  "output_tokens": 917,
+  "reasoning_tokens": 779,
+  "total_tokens": 5674,
+  "cost_usd": 0.034015,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 25933,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 101,
+    "sentences": 9,
+    "mean_sentence_words": 11.2,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe\n\nsqlpipe is a CLI tool that syncs Postgres tables to S3 as Parquet files. It reads rows from Postgres and converts the data to the Parquet format. Then it writes the Parquet files to an S3 bucket. Parquet provides compact columnar storage for data analysis. S3 provides durable object storage for exports and downstream data jobs.\n\nTeams can use sqlpipe to move relational data into an S3 data lake or archive. The files work with query engines, data warehouses, and other tools that support Parquet on S3. sqlpipe provides one command-line workflow for repeatable table exports. You can run it from a terminal, a scheduled job, or a CI pipeline. This workflow removes the need for a custom export script.",
+  "input_tokens": 4740,
+  "output_tokens": 1715,
+  "reasoning_tokens": 1552,
+  "total_tokens": 6455,
+  "cost_usd": 0.07515000000000001,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 48356,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 120,
+    "sentences": 10,
+    "mean_sentence_words": 12.0,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe v2.0\n\nsqlpipe v2.0 changes the `/v2/users` response, adds incremental processing, and improves Parquet write performance.\n\n## Breaking change\n\nBREAKING CHANGE: Before you use `/v2/users` with version 2.0, update clients to read `first_name` and `last_name`.\n\nThe endpoint no longer returns the `name` field. Clients that require `name` will fail to read user names. The new fields provide the first and last name as separate values.\n\n## Incremental processing\n\nUse the new `--incremental` flag to process only data that changed after the previous run.\n\nThis flag reduces repeated work for pipelines with frequent updates.\n\n## Parquet performance\n\nParquet writes are 40% faster than in sqlpipe v1.x. This improvement reduces write time for large data sets. Actual performance depends on the data, storage, and system resources.",
+  "input_tokens": 4759,
+  "output_tokens": 1227,
+  "reasoning_tokens": 1034,
+  "total_tokens": 5986,
+  "cost_usd": 0.060605000000000006,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 33649,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 114,
+    "sentences": 11,
+    "mean_sentence_words": 10.4,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Before the migration, make sure that the backup exists.",
+  "input_tokens": 4724,
+  "output_tokens": 198,
+  "reasoning_tokens": 181,
+  "total_tokens": 4922,
+  "cost_usd": 0.029560000000000003,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 11380,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 9,
+    "sentences": 1,
+    "mean_sentence_words": 9.0,
+    "longest_sentence_words": 9,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-sol_medium__skill__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nsqlpipe reports `dial tcp: i/o timeout` when it cannot reach the Postgres server.\n\n1. Make sure that the Postgres host name and port in the configuration are correct.\n2. Make sure that the sqlpipe host can reach the Postgres port.\n3. If a firewall or security group blocks the port, permit traffic from the sqlpipe host.\n4. If the network is slow, increase `source.connect_timeout_seconds` in the configuration.\n5. Run sqlpipe again.\n\n### S3 permission errors\n\nsqlpipe reports `AccessDenied` when the AWS identity does not have permission for the requested S3 operation.\n\n1. Make sure that sqlpipe uses the correct AWS profile, access key, or IAM role.\n2. Make sure that the identity can access the configured bucket and object prefix.\n3. Grant the required S3 actions in the IAM policy.\n4. If the bucket uses AWS KMS encryption, grant access to the KMS key.\n5. If a bucket policy denies access, change the policy to permit the sqlpipe identity.\n6. Run sqlpipe again.",
+  "input_tokens": 4729,
+  "output_tokens": 1162,
+  "reasoning_tokens": 923,
+  "total_tokens": 5891,
+  "cost_usd": 0.058505,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-sol",
+  "stop_reason": "stop",
+  "duration_ms": 34914,
+  "model": "openai-codex/gpt-5.6-sol:medium",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 156,
+    "sentences": 13,
+    "mean_sentence_words": 11.2,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.28
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe is a streaming export pipeline with three decoupled stages. A reader process queries Postgres using a cursor and emits rows in configurable batches, avoiding full-table buffering. Batches flow through bounded channels to provide backpressure when downstream work slows. The converter maps Postgres types to Parquet schemas and encodes each batch as a Parquet row group, preserving ordering and recording file metadata. Completed row groups are passed to the uploader, which assembles Parquet output and uploads it to S3 using multipart upload APIs. Multipart parts are buffered only as needed, enabling large exports with predictable memory use. The uploader retries transient S3 failures with backoff and can resume or abort incomplete uploads safely. Stage-level metrics, structured errors, and coordinated shutdown allow failures to stop the pipeline cleanly while preserving diagnostic context.",
+  "input_tokens": 76,
+  "output_tokens": 203,
+  "reasoning_tokens": 34,
+  "total_tokens": 279,
+  "cost_usd": 0.002588,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 7220,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 131,
+    "sentences": 8,
+    "mean_sentence_words": 16.4,
+    "longest_sentence_words": 23,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.53
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "AccessDenied: Access Denied\nUser is not authorized to perform: s3:PutObject",
+  "input_tokens": 67,
+  "output_tokens": 580,
+  "reasoning_tokens": 555,
+  "total_tokens": 647,
+  "cost_usd": 0.007094,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 14814,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 10,
+    "sentences": 1,
+    "mean_sentence_words": 8.0,
+    "longest_sentence_words": 8,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting started\n\nInstall `sqlpipe` with:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nConfirm the installation:\n\n```sh\nsqlpipe --version\n```\n\nNext, create a `sqlpipe.yaml` configuration file. Define your source and destination connections, then add the pipelines or jobs you want sqlpipe to run. Keep credentials out of version control by using environment variables or your preferred secret manager.\n\nExample workflow:\n\n```yaml\nsource: postgres://$SOURCE_DATABASE_URL\ndestination: postgres://$DESTINATION_DATABASE_URL\n\npipelines:\n  - name: sync_customers\n    query: SELECT * FROM customers\n    target: customers\n```\n\nSet any required environment variables, then run your first pipeline:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe reads the configuration, connects to the configured systems, and executes the defined pipeline. Use `--help` to explore available commands and options:\n\n```sh\nsqlpipe --help\n```",
+  "input_tokens": 85,
+  "output_tokens": 241,
+  "reasoning_tokens": 28,
+  "total_tokens": 326,
+  "cost_usd": 0.003062,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 8159,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 78,
+    "sentences": 9,
+    "mean_sentence_words": 8.7,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "**Resolved \u2014 Elevated API Errors**\n\nBetween 14:02 and 14:31 UTC, approximately 12% of API requests failed with HTTP 502 errors. The issue began after a deployment removed a required cache warmup step, causing backend services to experience elevated load during cache initialization.\n\nWe identified the deployment as the source of the failures and reverted it at 14:27 UTC. Error rates returned to normal by 14:31 UTC.\n\nWe are restoring the cache warmup step, adding deployment validation to detect its absence, and reviewing safeguards to reduce the impact of similar changes.",
+  "input_tokens": 87,
+  "output_tokens": 122,
+  "reasoning_tokens": 0,
+  "total_tokens": 209,
+  "cost_usd": 0.0016380000000000001,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 5790,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 90,
+    "sentences": 5,
+    "mean_sentence_words": 18.0,
+    "longest_sentence_words": 24,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 1.11
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe\n\nsqlpipe is a command-line tool for exporting PostgreSQL tables to Amazon S3 as efficient, analytics-ready Parquet files. It streams data directly from Postgres, handles large tables without requiring local staging, and organizes output for use with tools such as Athena, Spark, DuckDB, and Snowflake.\n\nDesigned for simple, repeatable data synchronization, sqlpipe lets you select tables or queries, configure S3 destinations, and run exports in scripts, cron jobs, or CI pipelines.",
+  "input_tokens": 70,
+  "output_tokens": 145,
+  "reasoning_tokens": 38,
+  "total_tokens": 215,
+  "cost_usd": 0.00188,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 6506,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 70,
+    "sentences": 3,
+    "mean_sentence_words": 23.3,
+    "longest_sentence_words": 27,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.86
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "## sqlpipe v2.0\n\nsqlpipe v2.0 introduces important API and performance improvements.\n\n### Breaking change: `/v2/users`\nThe `name` field has been replaced with separate `first_name` and `last_name` fields. Update clients, schemas, and downstream transformations that read or write user names.\n\n### New incremental mode\nA new `--incremental` flag enables incremental processing workflows, helping reduce work when operating on previously processed data.\n\n### Faster Parquet output\nParquet writes are now approximately 40% faster, improving throughput for export and pipeline workloads.\n\nPlease review integrations before upgrading, especially any consumers of the `/v2/users` response.",
+  "input_tokens": 89,
+  "output_tokens": 141,
+  "reasoning_tokens": 0,
+  "total_tokens": 230,
+  "cost_usd": 0.0018700000000000001,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 7174,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 75,
+    "sentences": 6,
+    "mean_sentence_words": 12.5,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 2,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 4,
+    "violations_per_100w": 5.33
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Verify backup before migration.",
+  "input_tokens": 54,
+  "output_tokens": 9,
+  "reasoning_tokens": 0,
+  "total_tokens": 63,
+  "cost_usd": 0.000216,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 3864,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 4,
+    "sentences": 1,
+    "mean_sentence_words": 4.0,
+    "longest_sentence_words": 4,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__baseline__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nIf `sqlpipe` times out while connecting to Postgres, verify the host, port, database name, and credentials in your connection string. Confirm that Postgres is running and accepting TCP connections on the configured port (usually `5432`). Check firewall rules, security groups, VPN access, and network policies between the machine running `sqlpipe` and the database. For managed databases, ensure your IP address is allowlisted. If SSL is required, include the appropriate SSL mode and certificates in the connection configuration. Test connectivity independently with `psql` to isolate whether the issue is with `sqlpipe` or the network.\n\n### S3 permission errors\n\nFor `AccessDenied` or permission-related S3 errors, verify the AWS credentials used by `sqlpipe`, including the active profile, environment variables, or IAM role. The identity needs permissions such as `s3:ListBucket`, `s3:GetObject`, and `s3:PutObject` for the target bucket and prefix. Also check bucket policies, KMS key permissions for encrypted objects, and the configured AWS region.",
+  "input_tokens": 59,
+  "output_tokens": 290,
+  "reasoning_tokens": 54,
+  "total_tokens": 349,
+  "cost_usd": 0.003598,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 9128,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 150,
+    "sentences": 9,
+    "mean_sentence_words": 16.7,
+    "longest_sentence_words": 23,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 3
+    },
+    "violations_total": 4,
+    "violations_per_100w": 2.67
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe moves data from Postgres to S3 through three processes. The reader process reads Postgres rows in batches. It sends each batch to the converter process. The reader uses a batch limit to control memory use.\n\nThe converter changes each batch into a Parquet row group. The uploader receives completed row groups from the converter. It writes the row groups to S3 as parts of a multipart object. Each part can contain one or more Parquet row groups. If an upload attempt fails, the uploader retries the part. The three processes operate at the same time.",
+  "input_tokens": 4746,
+  "output_tokens": 1130,
+  "reasoning_tokens": 1010,
+  "total_tokens": 5876,
+  "cost_usd": 0.023052000000000003,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 24903,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 96,
+    "sentences": 10,
+    "mean_sentence_words": 9.6,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "S3 upload failed: AccessDenied.\nThe IAM credentials do not have `s3:PutObject` permission.\nAdd `s3:PutObject` permission to the IAM policy, then run sqlpipe again.",
+  "input_tokens": 4737,
+  "output_tokens": 169,
+  "reasoning_tokens": 120,
+  "total_tokens": 4906,
+  "cost_usd": 0.011502,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 6639,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 23,
+    "sentences": 3,
+    "mean_sentence_words": 7.3,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting started\n\n1. Install sqlpipe on a supported Linux or macOS system.\n\n   ```sh\n   curl -sSL https://get.sqlpipe.dev | sh\n   ```\n\n2. If the command is unavailable, restart the terminal.\n\n3. Go to the directory for the data transfer project.\n\n4. Create `sqlpipe.yaml` in this directory.\n\n5. Add the source database details to `sqlpipe.yaml`.\n\n6. Add the destination database details to the same file.\n\n7. Make sure that both database accounts have the required access permissions.\n\n8. Review the configuration for correct host names, ports, database names, and credentials.\n\n9. Run the first transfer.\n\n   ```sh\n   sqlpipe run --config sqlpipe.yaml\n   ```\n\n10. If the command reports an error, read the error message.\n\n11. Correct the configuration.\n\n12. Run the command again.\n\nCAUTION: Do not commit passwords or access tokens to a shared repository. Unauthorized users can read these values.",
+  "input_tokens": 4755,
+  "output_tokens": 1535,
+  "reasoning_tokens": 1324,
+  "total_tokens": 6290,
+  "cost_usd": 0.027929999999999996,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 31586,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 122,
+    "sentences": 14,
+    "mean_sentence_words": 7.8,
+    "longest_sentence_words": 12,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "Between 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502 errors. A deployment at 14:02 removed the cache warmup step. Some API servers did not have cached data when they received requests. These servers returned HTTP 502 errors while they loaded the data. We reverted the deployment at 14:27 UTC. The error rate returned to normal at 14:31 UTC.\n\nWe will add a deployment check for the cache warmup step. We will also monitor cache warmup completion during future deployments.",
+  "input_tokens": 4757,
+  "output_tokens": 590,
+  "reasoning_tokens": 470,
+  "total_tokens": 5347,
+  "cost_usd": 0.016594,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 14231,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 83,
+    "sentences": 8,
+    "mean_sentence_words": 10.4,
+    "longest_sentence_words": 14,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.41
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe\n\nsqlpipe is a command-line tool that syncs Postgres tables to S3 as Parquet files. It reads table data from a Postgres database. It writes the data to an S3 bucket as Parquet files.\n\nUse sqlpipe in data pipelines that need Postgres table data in S3. The Parquet files store the exported data in a columnar format. Systems that read Parquet files from S3 can use this data for analysis, storage, or other processing.",
+  "input_tokens": 4740,
+  "output_tokens": 623,
+  "reasoning_tokens": 516,
+  "total_tokens": 5363,
+  "cost_usd": 0.016956,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 14857,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 73,
+    "sentences": 6,
+    "mean_sentence_words": 12.2,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe v2.0\n\n## Breaking change\n\nWARNING: Before you install v2.0, update clients that use `/v2/users`.\n\nThe endpoint no longer returns the `name` field. It returns `first_name` and `last_name` instead. This change can cause errors in clients that read `name`.\n\n## New flag\n\nUse `--incremental` to copy only data that changed after the previous successful run. The flag reduces copied data during later runs.\n\n## Performance\n\nParquet writes are 40% faster than in v1.x. Actual speed can change with the data size, storage system, and network speed.",
+  "input_tokens": 4759,
+  "output_tokens": 653,
+  "reasoning_tokens": 516,
+  "total_tokens": 5412,
+  "cost_usd": 0.017354,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 15509,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 78,
+    "sentences": 8,
+    "mean_sentence_words": 9.6,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Before you run the migration, make sure that the backup exists.",
+  "input_tokens": 884,
+  "output_tokens": 122,
+  "reasoning_tokens": 103,
+  "total_tokens": 4846,
+  "cost_usd": 0.004,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 5947,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/openai-codex_gpt-5.6-terra_medium__skill__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Connection timeouts\n\nsqlpipe stops with `dial tcp: i/o timeout` when it cannot reach the Postgres port.\n\n1. Make sure that the host can reach the Postgres port.\n2. Make sure that the firewall allows traffic to port 5432.\n3. If the database is managed, make sure that it accepts connections from the sqlpipe IP address.\n4. If the network is slow, increase `source.connect_timeout_seconds` in the configuration.\n5. Run the command again.\n\n## S3 permission errors\n\nsqlpipe reports an S3 permission error when its AWS identity cannot access the bucket.\n\n1. Make sure that the IAM role has `s3:GetObject` permission for the source bucket.\n2. Make sure that the IAM role has `s3:PutObject` permission for the destination bucket.\n3. If the bucket uses KMS encryption, make sure that the IAM role has KMS permissions.\n4. Make sure that the AWS Region in the configuration matches the bucket Region.\n5. Run the command again.",
+  "input_tokens": 4729,
+  "output_tokens": 636,
+  "reasoning_tokens": 418,
+  "total_tokens": 5365,
+  "cost_usd": 0.01709,
+  "provider": "openai-codex",
+  "model_id": "gpt-5.6-terra",
+  "stop_reason": "stop",
+  "duration_ms": 15135,
+  "model": "openai-codex/gpt-5.6-terra:medium",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 143,
+    "sentences": 12,
+    "mean_sentence_words": 11.1,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.4
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "Sqlpipe is a robust data ingestion pipeline designed to seamlessly export large datasets from PostgreSQL to Amazon S3. The architecture consists of three highly efficient, decoupled stages: a Reader, a Converter, and an Uploader. First, the Reader process queries Postgres, utilizing server-side cursors to stream rows in memory-bounded batches without overwhelming the database. Next, these batches are ingested by the Converter, which efficiently transforms the structured relational data into compressed Parquet row groups, optimizing for analytical query performance. Finally, the Parquet row groups are handed off to the Uploader. This component reliably writes the data to S3 using multipart object uploads. To guarantee data integrity and resilience against transient network failures, the Uploader is equipped with configurable automatic retries and exponential backoff, ensuring a fault-tolerant data transfer.",
+  "input_tokens": 79,
+  "output_tokens": 1900,
+  "reasoning_tokens": 1732,
+  "total_tokens": 1979,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 16604,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 127,
+    "sentences": 8,
+    "mean_sentence_words": 15.9,
+    "longest_sentence_words": 26,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 3,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 5,
+    "violations_per_100w": 3.94
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "AccessDenied: Access Denied\nstatus code: 403, request id: A1B2C3D4E5F6G7H8, host id: aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890AbCdEfGhIjKlMnOpQrStUvWxYz==",
+  "input_tokens": 70,
+  "output_tokens": 2094,
+  "reasoning_tokens": 2006,
+  "total_tokens": 2164,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 26815,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 12,
+    "sentences": 3,
+    "mean_sentence_words": 3.3,
+    "longest_sentence_words": 4,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "# Getting Started\n\n## Installation\n\nInstall sqlpipe with a single command:\n\n```bash\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThis downloads the latest binary and places it on your `PATH`. Verify the installation with `sqlpipe --version`.\n\n## Configuration\n\nCreate a configuration file named `sqlpipe.yaml` in your project directory. This file defines your data sources, pipelines, and execution settings. Start from a template:\n\n```bash\nsqlpipe init\n```\n\nEdit `sqlpipe.yaml` to point at your databases and describe the transformations you want to run. Detailed configuration options are covered in the [Configuration Reference](#).\n\n## Your First Run\n\nExecute your pipeline with:\n\n```bash\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe reads the config, connects to your sources, and processes the defined steps. Check the console output for progress and any validation errors.\n\n## Next Steps\n\n- Explore the full configuration schema\n- Learn about scheduling and automation\n- Browse example pipelines in the docs repository",
+  "input_tokens": 88,
+  "output_tokens": 252,
+  "reasoning_tokens": 38,
+  "total_tokens": 340,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 4873,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 119,
+    "sentences": 12,
+    "mean_sentence_words": 9.7,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 3
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.52
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "Between 14:02 and 14:31 UTC, a subset of users experienced elevated error rates on our API, with approximately 12% of requests failing with HTTP 502 (Bad Gateway) errors. The issue was traced back to a recent deployment that inadvertently removed the automated cache warmup step. This oversight caused origin servers to be overwhelmed by sudden traffic spikes. \n\nAt 14:27 UTC, our engineering team successfully reverted the problematic deployment. By 14:31 UTC, API error rates returned to normal levels and full service was restored. We are actively updating our deployment pipeline to prevent similar cache configuration oversights in the future.",
+  "input_tokens": 91,
+  "output_tokens": 1282,
+  "reasoning_tokens": 1150,
+  "total_tokens": 1373,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 15329,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 99,
+    "sentences": 6,
+    "mean_sentence_words": 16.5,
+    "longest_sentence_words": 28,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 1.01
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "**`sqlpipe`** is a fast, lightweight command-line tool designed to seamlessly synchronize PostgreSQL tables directly into Amazon S3 as Apache Parquet files. Built for modern data engineering workflows, it bridges the gap between transactional databases and cloud data lakes. Whether you are building an analytics pipeline or creating regular database backups, `sqlpipe` provides a reliable bridge for your data.\n\nBy converting row-based Postgres records into highly compressed, columnar Parquet format on the fly, the tool drastically reduces your S3 storage costs while maximizing query performance in downstream platforms like AWS Athena, Snowflake, or BigQuery. With simple configuration, robust incremental syncing, and zero required infrastructure, you can easily automate your data extraction and ensure your data lake is always up to date.",
+  "input_tokens": 73,
+  "output_tokens": 1430,
+  "reasoning_tokens": 1274,
+  "total_tokens": 1503,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 14297,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 122,
+    "sentences": 5,
+    "mean_sentence_words": 24.4,
+    "longest_sentence_words": 35,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 2,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 4,
+    "violations_per_100w": 3.28
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "We are excited to announce sqlpipe v2.0! This major release delivers significant performance upgrades, powerful new command-line features, and necessary API refinements to improve your overall workflow.\n\n**\u26a0\ufe0f Breaking Change**\nThe /v2/users endpoint structure has been updated. The previously combined name field is now split into separate first_name and last_name properties. Please update your API integrations and client wrappers to maintain compatibility.\n\n**\u2728 New --incremental Flag**\nYou can now utilize the new --incremental flag to easily append data to existing tables. This allows you to seamlessly resume large pipelines without needing a full historical data refresh.\n\n**\u26a1\ufe0f 40% Faster Parquet Writes**\nUnder-the-hood I/O optimizations now make writing Parquet files 40% faster, significantly reducing pipeline execution times.\n\nUpgrade today to experience faster data syncing!",
+  "input_tokens": 92,
+  "output_tokens": 2178,
+  "reasoning_tokens": 2002,
+  "total_tokens": 2270,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 23487,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 123,
+    "sentences": 9,
+    "mean_sentence_words": 13.7,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 3,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 4,
+    "violations_per_100w": 3.25
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Verify backup before migration.",
+  "input_tokens": 58,
+  "output_tokens": 431,
+  "reasoning_tokens": 424,
+  "total_tokens": 489,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 7804,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 4,
+    "sentences": 1,
+    "mean_sentence_words": 4.0,
+    "longest_sentence_words": 4,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__baseline__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "### Troubleshooting\n\n**Connection Timeouts to Postgres**\nIf `sqlpipe` hangs or throws a connection timeout when querying Postgres, first verify your network connectivity and firewall rules to ensure outbound traffic to the Postgres instance (usually port 5432) is allowed. If your database requires IP whitelisting, confirm that the machine executing `sqlpipe` is authorized in your database's `pg_hba.conf` file or your cloud provider's security group settings. To prevent indefinite hangs, you can append `connect_timeout=10` to your database connection string to force a faster failure.\n\n**S3 Permission Errors**\nWhen reading from or writing to S3, `sqlpipe` might return \"Access Denied\" or 403 Forbidden errors. This typically indicates an issue with your AWS credentials or IAM policies. Ensure the IAM role or user being used explicitly grants `s3:PutObject`, `s3:GetObject`, and `s3:ListBucket` permissions for the target S3 bucket. Finally, verify that your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables are correctly exported in your shell, and double-check the specified AWS region.",
+  "input_tokens": 61,
+  "output_tokens": 1241,
+  "reasoning_tokens": 998,
+  "total_tokens": 1302,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 12659,
+  "model": "zai/glm-5.2:max",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 154,
+    "sentences": 7,
+    "mean_sentence_words": 22.0,
+    "longest_sentence_words": 36,
+    "violations": {
+      "sentence_over_limit": 4,
+      "contraction": 0,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 3
+    },
+    "violations_total": 10,
+    "violations_per_100w": 6.49
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__architecture.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__architecture.json
@@ -1,0 +1,37 @@
+{
+  "text": "sqlpipe moves data from Postgres to S3 in three stages. A reader process, a converter, and an uploader form the pipeline. Each stage does one task and sends its output to the next stage.\n\nA reader process connects to Postgres and reads table rows in batches. Each batch contains a fixed number of rows. The reader sends each batch to the converter.\n\nA converter receives each batch from the reader. It writes the batch as a Parquet row group. This stage changes the row format from Postgres to Parquet. The converter sends each row group to the uploader.\n\nAn uploader writes each Parquet row group to S3 as a multipart object. If an upload fails, the uploader retries the transfer. The uploader stops after a maximum number of retries.",
+  "input_tokens": 81,
+  "output_tokens": 2431,
+  "reasoning_tokens": 2275,
+  "total_tokens": 7184,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 23616,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 129,
+    "sentences": 13,
+    "mean_sentence_words": 9.9,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__error-message.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__error-message.json
@@ -1,0 +1,37 @@
+{
+  "text": "```\nS3 upload failed: AccessDenied.\nThe IAM credentials lack the s3:PutObject permission on the target bucket.\nGrant s3:PutObject to the IAM role or user, then run sqlpipe again.\n```",
+  "input_tokens": 72,
+  "output_tokens": 518,
+  "reasoning_tokens": 470,
+  "total_tokens": 5262,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 7706,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 1,
+    "sentences": 0,
+    "mean_sentence_words": 0.0,
+    "longest_sentence_words": 0,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__getting-started.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__getting-started.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Getting Started\n\nInstall sqlpipe with this command:\n\n```\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThis installs the `sqlpipe` binary on your system.\n\nThen create a file named `sqlpipe.yaml`. This configuration file tells sqlpipe the source database, the target database, and the data to move.\n\nWrite the connection details for both databases in the file. Include the host, port, and credentials for each database. List the tables that you want to transfer.\n\nBefore you run the command, make sure that both databases accept connections from the host of sqlpipe.\n\nThen start the transfer:\n\n```\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe reads the configuration file and moves the data from the source to the target.",
+  "input_tokens": 90,
+  "output_tokens": 2374,
+  "reasoning_tokens": 2215,
+  "total_tokens": 7136,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 25951,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 99,
+    "sentences": 10,
+    "mean_sentence_words": 9.9,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__incident-report.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__incident-report.json
@@ -1,0 +1,37 @@
+{
+  "text": "At 14:02 UTC, a deployment removed the cache warmup step. As a result, 12% of API requests failed with HTTP 502 between 14:02 and 14:31 UTC. The cache warmup step loads data into memory before the API starts. Without this step, the API did not respond to requests fast enough.\n\nThe operations team reverted the deployment at 14:27 UTC. All API requests succeeded again by 14:31 UTC.\n\nWe will add a check to the deployment process. This check will make sure that the cache warmup step runs before each deployment.",
+  "input_tokens": 93,
+  "output_tokens": 3365,
+  "reasoning_tokens": 3240,
+  "total_tokens": 8130,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 36883,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 90,
+    "sentences": 8,
+    "mean_sentence_words": 11.2,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__readme-intro.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__readme-intro.json
@@ -1,0 +1,37 @@
+{
+  "text": "**sqlpipe** is a command-line tool that syncs data from Postgres tables to S3. It writes each table as Parquet files in an S3 bucket that you specify. sqlpipe reads rows from your database in batches. It converts each batch to Parquet format and uploads the files to S3. You can run sqlpipe once or on a schedule. It stores its settings in a YAML configuration file.\n\nParquet is a columnar file format. It compresses data more efficiently than CSV or JSON. This makes Parquet files smaller and faster to query. Tools such as Athena, DuckDB, and Spark can read the files directly from S3. You do not need to download the files before you query them.",
+  "input_tokens": 4747,
+  "output_tokens": 5176,
+  "reasoning_tokens": 5026,
+  "total_tokens": 9923,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 52519,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 116,
+    "sentences": 11,
+    "mean_sentence_words": 10.5,
+    "longest_sentence_words": 14,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.86
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__release-notes.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__release-notes.json
@@ -1,0 +1,37 @@
+{
+  "text": "# sqlpipe v2.0\n\nThis release has one breaking change and two improvements.\n\n**Breaking change: `/v2/users` name fields**\n\nWARNING: Update your code before you install v2.0. The `/v2/users` endpoint does not have the `name` field. The endpoint now returns `first_name` and `last_name`. Code that reads `name` will fail.\n\n**New `--incremental` flag**\n\nUse the `--incremental` flag to copy only new or changed rows. This flag makes large copies faster when only a small part of the data changes. For example, a daily copy of a table with many rows can finish in seconds, not minutes.\n\n**40% faster Parquet writes**\n\nParquet writes are 40% faster than in v1.0. Large exports complete in less time.",
+  "input_tokens": 94,
+  "output_tokens": 5343,
+  "reasoning_tokens": 5169,
+  "total_tokens": 10109,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 57661,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 109,
+    "sentences": 12,
+    "mean_sentence_words": 9.1,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.92
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__runbook-terse.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__runbook-terse.json
@@ -1,0 +1,37 @@
+{
+  "text": "Before the migration, make sure that the backup exists.",
+  "input_tokens": 59,
+  "output_tokens": 626,
+  "reasoning_tokens": 613,
+  "total_tokens": 5357,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 11085,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 9,
+    "sentences": 1,
+    "mean_sentence_words": 9.0,
+    "longest_sentence_words": 9,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__troubleshooting.json
+++ b/evals/results/pi-2026-07-31/raw/zai_glm-5.2_max__skill__troubleshooting.json
@@ -1,0 +1,37 @@
+{
+  "text": "## Troubleshooting\n\n**Connection timeouts to Postgres**\n\nsqlpipe stops with `dial tcp: i/o timeout` when it cannot reach the Postgres port (5432 by default).\n\n1. Make sure that the host that runs sqlpipe can reach the Postgres port. A firewall or security group usually blocks it.\n2. If the database is managed (RDS, Cloud SQL), make sure that the instance accepts connections from the IP of sqlpipe.\n3. If the network is slow, increase `source.connect_timeout_seconds` in the configuration.\n\n**S3 permission errors**\n\nsqlpipe fails with `AccessDenied` when the AWS credentials do not have the correct permissions.\n\n1. Make sure that the IAM user or role has read and write access to the target S3 bucket.\n2. If you use a bucket policy, make sure that the policy permits the sqlpipe user.\n3. If sqlpipe runs on EC2, make sure that the instance role includes the S3 permissions.",
+  "input_tokens": 63,
+  "output_tokens": 1563,
+  "reasoning_tokens": 1359,
+  "total_tokens": 6298,
+  "cost_usd": 0,
+  "provider": "zai",
+  "model_id": "glm-5.2",
+  "stop_reason": "stop",
+  "duration_ms": 14964,
+  "model": "zai/glm-5.2:max",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 140,
+    "sentences": 9,
+    "mean_sentence_words": 14.9,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.43
+  }
+}

--- a/evals/results/pi-2026-07-31/results.json
+++ b/evals/results/pi-2026-07-31/results.json
@@ -1,0 +1,168 @@
+{
+  "generated": "2026-07-31",
+  "models": [
+    {
+      "model": "zai/glm-5.2:max",
+      "baseline": {
+        "violations_per_100w": 2.56,
+        "weighted_violations_per_100w": 3.55,
+        "violations_total": 27,
+        "mean_sentence_words": 13.7,
+        "mean_final_words": 95.0,
+        "provider_output_tokens": 10808,
+        "reasoning_tokens": 9624,
+        "approximate_final_text_tokens": 1184,
+        "cost_usd": 0,
+        "duration_seconds": 121.9,
+        "runs": 8
+      },
+      "skill": {
+        "violations_per_100w": 0.4,
+        "weighted_violations_per_100w": 0.58,
+        "violations_total": 4,
+        "mean_sentence_words": 9.3,
+        "mean_final_words": 86.6,
+        "provider_output_tokens": 21396,
+        "reasoning_tokens": 20367,
+        "approximate_final_text_tokens": 1029,
+        "cost_usd": 0,
+        "duration_seconds": 230.4,
+        "runs": 8
+      },
+      "reduction_pct": 84.4,
+      "scenario_outcomes": {
+        "improved": 6,
+        "tied": 2,
+        "worsened": 0
+      },
+      "cost_usd": 0,
+      "duration_seconds": 352.3
+    },
+    {
+      "model": "openai-codex/gpt-5.6-sol:medium",
+      "baseline": {
+        "violations_per_100w": 1.33,
+        "weighted_violations_per_100w": 1.68,
+        "violations_total": 12,
+        "mean_sentence_words": 12.3,
+        "mean_final_words": 89.5,
+        "provider_output_tokens": 3036,
+        "reasoning_tokens": 1829,
+        "approximate_final_text_tokens": 1207,
+        "cost_usd": 0.094015,
+        "duration_seconds": 117.7,
+        "runs": 8
+      },
+      "skill": {
+        "violations_per_100w": 0.16,
+        "weighted_violations_per_100w": 0.25,
+        "violations_total": 2,
+        "mean_sentence_words": 9.8,
+        "mean_final_words": 100.5,
+        "provider_output_tokens": 8948,
+        "reasoning_tokens": 7711,
+        "approximate_final_text_tokens": 1237,
+        "cost_usd": 0.440895,
+        "duration_seconds": 257.1,
+        "runs": 8
+      },
+      "reduction_pct": 88.0,
+      "scenario_outcomes": {
+        "improved": 5,
+        "tied": 3,
+        "worsened": 0
+      },
+      "cost_usd": 0.53491,
+      "duration_seconds": 374.8
+    },
+    {
+      "model": "openai-codex/gpt-5.6-terra:medium",
+      "baseline": {
+        "violations_per_100w": 1.69,
+        "weighted_violations_per_100w": 2.14,
+        "violations_total": 13,
+        "mean_sentence_words": 13.4,
+        "mean_final_words": 76.0,
+        "provider_output_tokens": 1731,
+        "reasoning_tokens": 709,
+        "approximate_final_text_tokens": 1022,
+        "cost_usd": 0.021946,
+        "duration_seconds": 62.7,
+        "runs": 8
+      },
+      "skill": {
+        "violations_per_100w": 0.48,
+        "weighted_violations_per_100w": 0.64,
+        "violations_total": 4,
+        "mean_sentence_words": 9.9,
+        "mean_final_words": 78.6,
+        "provider_output_tokens": 5458,
+        "reasoning_tokens": 4477,
+        "approximate_final_text_tokens": 981,
+        "cost_usd": 0.134478,
+        "duration_seconds": 128.8,
+        "runs": 8
+      },
+      "reduction_pct": 71.6,
+      "scenario_outcomes": {
+        "improved": 4,
+        "tied": 3,
+        "worsened": 1
+      },
+      "cost_usd": 0.156424,
+      "duration_seconds": 191.5
+    },
+    {
+      "model": "openai-codex/gpt-5.6-luna:medium",
+      "baseline": {
+        "violations_per_100w": 1.28,
+        "weighted_violations_per_100w": 1.7,
+        "violations_total": 12,
+        "mean_sentence_words": 13.7,
+        "mean_final_words": 88.2,
+        "provider_output_tokens": 1968,
+        "reasoning_tokens": 807,
+        "approximate_final_text_tokens": 1161,
+        "cost_usd": 0.002479,
+        "duration_seconds": 65.6,
+        "runs": 8
+      },
+      "skill": {
+        "violations_per_100w": 0.42,
+        "weighted_violations_per_100w": 0.65,
+        "violations_total": 5,
+        "mean_sentence_words": 10.2,
+        "mean_final_words": 96.2,
+        "provider_output_tokens": 5070,
+        "reasoning_tokens": 3914,
+        "approximate_final_text_tokens": 1156,
+        "cost_usd": 0.013673,
+        "duration_seconds": 120.5,
+        "runs": 8
+      },
+      "reduction_pct": 67.2,
+      "scenario_outcomes": {
+        "improved": 5,
+        "tied": 2,
+        "worsened": 1
+      },
+      "cost_usd": 0.016152,
+      "duration_seconds": 186.1
+    }
+  ],
+  "runs": 64,
+  "scenarios_per_condition": 8,
+  "conditions": [
+    "baseline",
+    "skill"
+  ],
+  "system_prompt": "Return only the final text requested by the user.",
+  "isolation": {
+    "tools": "disabled",
+    "skills": "disabled",
+    "prompt_templates": "disabled",
+    "extensions": "disabled",
+    "context_files": "disabled",
+    "session_persistence": "disabled"
+  }
+}

--- a/evals/run_pi_bench.py
+++ b/evals/run_pi_bench.py
@@ -1,0 +1,539 @@
+"""Benchmark the simple-english skill through isolated Pi CLI calls.
+
+For each model, condition, and scenario, this script runs a headless `pi -p`
+call. It lints each final response with ste_lint.py and writes resumable raw
+results, results.json, and RESULTS.md to a separate results directory.
+
+Usage:
+  python3 evals/run_pi_bench.py --model PROVIDER/MODEL:THINKING
+  python3 evals/run_pi_bench.py --model MODEL --smoke
+  python3 evals/run_pi_bench.py --model MODEL --report-only
+"""
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import subprocess
+import time
+
+import ste_lint
+
+HERE = pathlib.Path(__file__).resolve().parent
+SKILL_PATH = HERE.parent / "skills" / "simple-english" / "SKILL.md"
+SCENARIOS_PATH = HERE / "scenarios.json"
+DEFAULT_RESULTS_DIRECTORY = HERE / "results" / "pi"
+CONDITIONS = ("baseline", "skill")
+NEUTRAL_SYSTEM_PROMPT = "Return only the final text requested by the user."
+CALL_TIMEOUT_SECONDS = 300
+CALL_RETRY_LIMIT = 2
+INTER_CALL_DELAY_SECONDS = 2
+
+
+def build_benchmark_prompt(scenario, condition, skill_text):
+    """Build the existing baseline or simple-english skill benchmark prompt."""
+    if condition == "baseline":
+        return scenario["prompt"]
+    if condition != "skill":
+        raise ValueError(f"Unknown benchmark condition: {condition}")
+    return (
+        "Follow these writing instructions exactly, including the self-check step:\n\n"
+        + skill_text
+        + "\n\n---\n\nTask: "
+        + scenario["prompt"]
+        + "\n\nReturn only the final text, no rule commentary."
+    )
+
+
+def parse_pi_json_events(stdout):
+    """Extract final assistant text and usage from Pi newline-delimited JSON events."""
+    final_message = None
+    for line_number, line in enumerate(stdout.splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                f"Pi returned invalid JSON on output line {line_number}: {error}"
+            ) from error
+        message = event.get("message", {})
+        if event.get("type") == "message_end" and message.get("role") == "assistant":
+            final_message = message
+
+    if final_message is None:
+        raise RuntimeError("Pi benchmark call returned no final assistant message")
+
+    text = "".join(
+        part.get("text", "")
+        for part in final_message.get("content", [])
+        if part.get("type") == "text"
+    )
+    if not text.strip():
+        raise RuntimeError(
+            "Pi benchmark call returned an empty final assistant message"
+        )
+
+    usage = final_message.get("usage", {})
+    cost = usage.get("cost", {})
+    return {
+        "text": text,
+        "input_tokens": usage.get("input"),
+        "output_tokens": usage.get("output"),
+        "reasoning_tokens": usage.get("reasoning"),
+        "total_tokens": usage.get("totalTokens"),
+        "cost_usd": cost.get("total"),
+        "provider": final_message.get("provider"),
+        "model_id": final_message.get("model"),
+        "stop_reason": final_message.get("stopReason"),
+    }
+
+
+def call_pi_model(prompt, model_spec):
+    """Generate one response with tools and ambient Pi context disabled."""
+    command = [
+        "pi",
+        "-p",
+        "--model",
+        model_spec,
+        "--mode",
+        "json",
+        "--no-session",
+        "--no-tools",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-extensions",
+        "--no-context-files",
+        "--system-prompt",
+        NEUTRAL_SYSTEM_PROMPT,
+        prompt,
+    ]
+    started_at = time.monotonic()
+    process = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CALL_TIMEOUT_SECONDS,
+        cwd="/tmp",
+    )
+    duration_ms = round(1000 * (time.monotonic() - started_at))
+    if process.returncode != 0:
+        stderr = process.stderr.strip()
+        raise RuntimeError(
+            f"Pi benchmark call failed for {model_spec} with exit "
+            f"{process.returncode}: {stderr[:1000]}"
+        )
+
+    result = parse_pi_json_events(process.stdout)
+    result["duration_ms"] = duration_ms
+    return result
+
+
+def model_spec_file_slug(model_spec):
+    """Convert a provider/model/thinking specification to a flat filename slug."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", model_spec)
+
+
+def raw_result_path(raw_directory, model_spec, condition, scenario_id):
+    """Return the resumable raw result path for one benchmark matrix cell."""
+    return raw_directory / (
+        f"{model_spec_file_slug(model_spec)}__{condition}__{scenario_id}.json"
+    )
+
+
+def call_pi_model_with_retries(prompt, model_spec):
+    """Retry one Pi generation after timeout or invalid model output."""
+    for attempt in range(1, CALL_RETRY_LIMIT + 1):
+        try:
+            return call_pi_model(prompt, model_spec)
+        except (RuntimeError, subprocess.TimeoutExpired) as error:
+            print(f"  attempt {attempt} failed: {error}", flush=True)
+            if attempt == CALL_RETRY_LIMIT:
+                raise RuntimeError(str(error)) from error
+            time.sleep(INTER_CALL_DELAY_SECONDS)
+    raise AssertionError("Pi retry loop ended without a result or error")
+
+
+def save_benchmark_cell(model_spec, condition, scenario, skill_text, output_path):
+    """Generate, lint, and save one benchmark matrix cell."""
+    prompt = build_benchmark_prompt(scenario, condition, skill_text)
+    result = call_pi_model_with_retries(prompt, model_spec)
+    result.update(
+        model=model_spec,
+        condition=condition,
+        scenario=scenario["id"],
+        type=scenario["type"],
+        lint=ste_lint.lint(result["text"], scenario["type"]),
+    )
+    output_path.write_text(json.dumps(result, indent=2) + "\n")
+    print(
+        f"  OK {result['duration_ms'] / 1000:.1f}s "
+        f"{result.get('output_tokens')} output tokens "
+        f"{result['lint']['violations_per_100w']} violations/100w",
+        flush=True,
+    )
+
+
+def generate_benchmark_matrix(models, scenarios, results_directory):
+    """Run missing matrix cells and save each successful response immediately."""
+    skill_text = SKILL_PATH.read_text()
+    raw_directory = results_directory / "raw"
+    failures_path = results_directory / "failures.json"
+    raw_directory.mkdir(parents=True, exist_ok=True)
+    failures = []
+    matrix = [
+        (model_spec, condition, scenario)
+        for model_spec in models
+        for condition in CONDITIONS
+        for scenario in scenarios
+    ]
+
+    for index, (model_spec, condition, scenario) in enumerate(matrix, 1):
+        output_path = raw_result_path(
+            raw_directory, model_spec, condition, scenario["id"]
+        )
+        if output_path.exists():
+            print(
+                f"[{index}/{len(matrix)}] SKIP {model_spec} "
+                f"{condition} {scenario['id']}",
+                flush=True,
+            )
+            continue
+
+        print(
+            f"[{index}/{len(matrix)}] RUN  {model_spec} {condition} {scenario['id']}",
+            flush=True,
+        )
+        try:
+            save_benchmark_cell(
+                model_spec, condition, scenario, skill_text, output_path
+            )
+        except RuntimeError as error:
+            failures.append(
+                {
+                    "model": model_spec,
+                    "condition": condition,
+                    "scenario": scenario["id"],
+                    "error": str(error),
+                }
+            )
+            failures_path.write_text(json.dumps(failures, indent=2) + "\n")
+        time.sleep(INTER_CALL_DELAY_SECONDS)
+
+    if not failures and failures_path.exists():
+        failures_path.unlink()
+    return failures
+
+
+def arithmetic_mean(values):
+    """Return the arithmetic mean of a non-empty sequence."""
+    return sum(values) / len(values)
+
+
+def aggregate_condition_rows(condition_rows):
+    """Aggregate one model and condition without hiding final-text length."""
+    violations = sum(row["lint"]["violations_total"] for row in condition_rows)
+    words = sum(row["lint"]["words"] for row in condition_rows)
+    output_tokens = sum(row.get("output_tokens") or 0 for row in condition_rows)
+    reasoning_tokens = sum(row.get("reasoning_tokens") or 0 for row in condition_rows)
+    return {
+        "violations_per_100w": round(
+            arithmetic_mean(
+                [row["lint"]["violations_per_100w"] for row in condition_rows]
+            ),
+            2,
+        ),
+        "weighted_violations_per_100w": round(100 * violations / words, 2),
+        "violations_total": violations,
+        "mean_sentence_words": round(
+            arithmetic_mean(
+                [row["lint"]["mean_sentence_words"] for row in condition_rows]
+            ),
+            1,
+        ),
+        "mean_final_words": round(words / len(condition_rows), 1),
+        "provider_output_tokens": output_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "approximate_final_text_tokens": output_tokens - reasoning_tokens,
+        "cost_usd": round(sum(row.get("cost_usd") or 0 for row in condition_rows), 6),
+        "duration_seconds": round(
+            sum(row["duration_ms"] for row in condition_rows) / 1000, 1
+        ),
+        "runs": len(condition_rows),
+    }
+
+
+def select_complete_condition_rows(
+    model_spec, model_rows, condition, expected_scenario_ids
+):
+    """Select one condition and reject missing scenario results."""
+    condition_rows = [
+        row
+        for row in model_rows
+        if row["condition"] == condition and row["scenario"] in expected_scenario_ids
+    ]
+    observed_scenario_ids = {row["scenario"] for row in condition_rows}
+    if observed_scenario_ids != expected_scenario_ids:
+        missing = sorted(expected_scenario_ids - observed_scenario_ids)
+        raise RuntimeError(
+            f"Incomplete benchmark results for {model_spec} {condition}; "
+            f"missing scenarios: {missing}"
+        )
+    return condition_rows
+
+
+def calculate_reduction_percentage(baseline_rate, skill_rate):
+    """Calculate percentage reduction unless the baseline rate is zero."""
+    if not baseline_rate:
+        return None
+    return round(100 * (baseline_rate - skill_rate) / baseline_rate, 1)
+
+
+def count_scenario_outcomes(scenario_rates, expected_scenario_ids):
+    """Count scenarios whose skill rate improved, tied, or worsened."""
+    outcomes = {"improved": 0, "tied": 0, "worsened": 0}
+    for scenario_id in expected_scenario_ids:
+        baseline = scenario_rates["baseline"][scenario_id]
+        skill = scenario_rates["skill"][scenario_id]
+        if skill < baseline:
+            outcomes["improved"] += 1
+        elif skill > baseline:
+            outcomes["worsened"] += 1
+        else:
+            outcomes["tied"] += 1
+    return outcomes
+
+
+def aggregate_model_results(model_spec, rows, expected_scenario_ids):
+    """Aggregate baseline and skill conditions for one model."""
+    model_rows = [row for row in rows if row["model"] == model_spec]
+    rows_by_condition = {
+        condition: select_complete_condition_rows(
+            model_spec, model_rows, condition, expected_scenario_ids
+        )
+        for condition in CONDITIONS
+    }
+    summaries = {
+        condition: aggregate_condition_rows(condition_rows)
+        for condition, condition_rows in rows_by_condition.items()
+    }
+    scenario_rates = {
+        condition: {
+            row["scenario"]: row["lint"]["violations_per_100w"]
+            for row in condition_rows
+        }
+        for condition, condition_rows in rows_by_condition.items()
+    }
+    baseline = summaries["baseline"]
+    skill = summaries["skill"]
+    return {
+        "model": model_spec,
+        "baseline": baseline,
+        "skill": skill,
+        "reduction_pct": calculate_reduction_percentage(
+            baseline["violations_per_100w"], skill["violations_per_100w"]
+        ),
+        "scenario_outcomes": count_scenario_outcomes(
+            scenario_rates, expected_scenario_ids
+        ),
+        "cost_usd": round(baseline["cost_usd"] + skill["cost_usd"], 6),
+        "duration_seconds": round(
+            baseline["duration_seconds"] + skill["duration_seconds"], 1
+        ),
+    }
+
+
+def aggregate_benchmark_results(models, scenarios, results_directory):
+    """Aggregate a complete raw matrix into per-model baseline comparisons."""
+    expected_scenario_ids = {scenario["id"] for scenario in scenarios}
+    raw_directory = results_directory / "raw"
+    rows = [
+        json.loads(path.read_text()) for path in sorted(raw_directory.glob("*.json"))
+    ]
+    selected_rows = [
+        row
+        for row in rows
+        if row["model"] in models and row["scenario"] in expected_scenario_ids
+    ]
+    return {
+        "generated": datetime.datetime.now(datetime.UTC).date().isoformat(),
+        "models": [
+            aggregate_model_results(model_spec, rows, expected_scenario_ids)
+            for model_spec in models
+        ],
+        "runs": len(selected_rows),
+        "scenarios_per_condition": len(scenarios),
+        "conditions": list(CONDITIONS),
+        "system_prompt": NEUTRAL_SYSTEM_PROMPT,
+        "isolation": {
+            "tools": "disabled",
+            "skills": "disabled",
+            "prompt_templates": "disabled",
+            "extensions": "disabled",
+            "context_files": "disabled",
+            "session_persistence": "disabled",
+        },
+    }
+
+
+def format_reproduction_command(models, results_directory):
+    """Format the exact model portfolio as a copyable benchmark command."""
+    lines = [
+        "python3 evals/run_pi_bench.py \\",
+        f"  --results-dir {results_directory} \\",
+    ]
+    for index, model_spec in enumerate(models):
+        suffix = " \\" if index < len(models) - 1 else ""
+        lines.append(f"  --model {model_spec}{suffix}")
+    return "\n".join(lines)
+
+
+def write_benchmark_report(results, models, results_directory):
+    """Write machine-readable and human-readable Pi benchmark summaries."""
+    results_directory.mkdir(parents=True, exist_ok=True)
+    (results_directory / "results.json").write_text(
+        json.dumps(results, indent=2) + "\n"
+    )
+
+    reductions = [
+        row["reduction_pct"]
+        for row in results["models"]
+        if row["reduction_pct"] is not None
+    ]
+    if reductions:
+        headline = (
+            f"**The skill reduced mean linter violations by {min(reductions):.1f}% to "
+            f"{max(reductions):.1f}% across {len(results['models'])} models.**"
+        )
+    else:
+        headline = (
+            "**Every baseline had zero measured violations, so percentage reduction "
+            "is undefined.**"
+        )
+
+    model_count = len(results["models"])
+    model_label = "model" if model_count == 1 else "models"
+    scenario_count = results["scenarios_per_condition"]
+    scenario_label = "scenario" if scenario_count == 1 else "scenarios"
+    lines = [
+        "# Pi benchmark results",
+        "",
+        headline,
+        "",
+        (
+            f"This run contains {results['runs']} generations: "
+            f"{model_count} {model_label} x {scenario_count} {scenario_label} "
+            "x 2 conditions."
+        ),
+        "",
+        (
+            "| Model | Baseline viol/100w | Skill viol/100w | Reduction | "
+            "Final words (base -> skill) | Scenarios (better/tied/worse) | Cost |"
+        ),
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in results["models"]:
+        baseline = row["baseline"]
+        skill = row["skill"]
+        outcomes = row["scenario_outcomes"]
+        reduction = (
+            f"{row['reduction_pct']:.1f}%"
+            if row["reduction_pct"] is not None
+            else "n/a"
+        )
+        lines.append(
+            f"| `{row['model']}` | {baseline['violations_per_100w']:.2f} | "
+            f"{skill['violations_per_100w']:.2f} | {reduction} | "
+            f"{baseline['mean_final_words']:.1f} -> {skill['mean_final_words']:.1f} | "
+            f"{outcomes['improved']}/{outcomes['tied']}/{outcomes['worsened']} | "
+            f"${row['cost_usd']:.6f} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Method",
+            "",
+            "The runner used the same scenarios, skill prompt, linter, and per-scenario averaging as `run_bench.py`.",
+            "It sent only the scenario prompt for the baseline condition.",
+            "It added the complete `SKILL.md` text for the skill condition.",
+            f"Both conditions used this neutral system prompt: `{results['system_prompt']}`",
+            "",
+            "Pi tools, skills, prompt templates, extensions, context files, and session persistence were disabled.",
+            "The runner made one generation for each matrix cell and did not run a judge pass.",
+            "",
+            "## Reproduce",
+            "",
+            "```bash",
+            format_reproduction_command(models, results_directory),
+            "```",
+            "",
+            "Delete `raw/` first to replace the committed generations. Existing raw files are skipped.",
+            "",
+            "## Caveats",
+            "",
+            "- The regex linter undercounts some violations and reports some false positives.",
+            "  For example, it treats descriptive sentences with a non-leading `when` clause as trailing conditions.",
+            "- One generation per cell does not measure model variance.",
+            "- Provider output-token counts can include hidden reasoning tokens.",
+            "  The table reports final-text word counts instead.",
+            "- Costs are provider-reported estimates, not billing records.",
+            "- The run measures the linter score, not ASD-STE100 certification or overall writing quality.",
+        ]
+    )
+    report = "\n".join(lines) + "\n"
+    (results_directory / "RESULTS.md").write_text(report)
+    print(report)
+
+
+def parse_command_line_arguments():
+    """Parse explicit model portfolio and result-location arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        dest="models",
+        action="append",
+        required=True,
+        help="Pi model specification; repeat for each model",
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=pathlib.Path,
+        default=DEFAULT_RESULTS_DIRECTORY,
+        help=f"result directory (default: {DEFAULT_RESULTS_DIRECTORY})",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="run the first two scenarios only",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="rebuild summaries from existing raw result files",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_command_line_arguments()
+    scenarios = json.loads(SCENARIOS_PATH.read_text())
+    if args.smoke:
+        scenarios = scenarios[:2]
+
+    if not args.report_only:
+        failures = generate_benchmark_matrix(args.models, scenarios, args.results_dir)
+        if failures:
+            raise SystemExit(
+                f"Benchmark stopped with {len(failures)} failed matrix cells; "
+                f"see {args.results_dir / 'failures.json'}"
+            )
+
+    results = aggregate_benchmark_results(args.models, scenarios, args.results_dir)
+    write_benchmark_report(results, args.models, args.results_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/test_run_pi_bench.py
+++ b/evals/test_run_pi_bench.py
@@ -1,0 +1,175 @@
+"""Tests for the Pi benchmark runner's stable input and output boundaries."""
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import run_pi_bench
+
+
+class PiJsonEventParsingTests(unittest.TestCase):
+    def test_extracts_final_text_and_usage_from_assistant_message(self):
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": {
+                            "role": "user",
+                            "content": [{"type": "text", "text": "prompt"}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": {
+                            "role": "assistant",
+                            "provider": "example-provider",
+                            "model": "example-model",
+                            "content": [
+                                {"type": "thinking", "thinking": "hidden"},
+                                {"type": "text", "text": "final text"},
+                            ],
+                            "usage": {
+                                "input": 10,
+                                "output": 7,
+                                "reasoning": 3,
+                                "totalTokens": 17,
+                                "cost": {"total": 0.25},
+                            },
+                            "stopReason": "stop",
+                        },
+                    }
+                ),
+            ]
+        )
+
+        result = run_pi_bench.parse_pi_json_events(stdout)
+
+        self.assertEqual(result["text"], "final text")
+        self.assertEqual(result["input_tokens"], 10)
+        self.assertEqual(result["output_tokens"], 7)
+        self.assertEqual(result["reasoning_tokens"], 3)
+        self.assertEqual(result["cost_usd"], 0.25)
+        self.assertEqual(result["provider"], "example-provider")
+        self.assertEqual(result["model_id"], "example-model")
+
+    def test_rejects_output_without_a_final_assistant_message(self):
+        stdout = json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "prompt"}],
+                },
+            }
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "no final assistant message"):
+            run_pi_bench.parse_pi_json_events(stdout)
+
+
+class BenchmarkPromptTests(unittest.TestCase):
+    def test_baseline_prompt_does_not_include_the_skill(self):
+        scenario = {"prompt": "Write the document."}
+
+        prompt = run_pi_bench.build_benchmark_prompt(
+            scenario, "baseline", "SKILL CONTENT"
+        )
+
+        self.assertEqual(prompt, "Write the document.")
+
+    def test_skill_prompt_includes_the_skill_and_original_task(self):
+        scenario = {"prompt": "Write the document."}
+
+        prompt = run_pi_bench.build_benchmark_prompt(scenario, "skill", "SKILL CONTENT")
+
+        self.assertIn("SKILL CONTENT", prompt)
+        self.assertIn("Task: Write the document.", prompt)
+        self.assertTrue(
+            prompt.endswith("Return only the final text, no rule commentary.")
+        )
+
+    def test_model_spec_file_slug_is_safe_for_provider_and_thinking_suffixes(self):
+        slug = run_pi_bench.model_spec_file_slug("openai-codex/gpt-5.6-sol:medium")
+
+        self.assertEqual(slug, "openai-codex_gpt-5.6-sol_medium")
+
+
+class BenchmarkAggregationTests(unittest.TestCase):
+    def test_smoke_aggregation_ignores_other_scenario_rows(self):
+        model = "example/model:medium"
+        expected_scenario = {"id": "expected"}
+        rows = [
+            self.make_raw_row(model, condition, scenario_id)
+            for condition in run_pi_bench.CONDITIONS
+            for scenario_id in ("expected", "extra")
+        ]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            results_directory = pathlib.Path(temporary_directory)
+            raw_directory = results_directory / "raw"
+            raw_directory.mkdir()
+            for index, row in enumerate(rows):
+                (raw_directory / f"{index}.json").write_text(json.dumps(row))
+
+            results = run_pi_bench.aggregate_benchmark_results(
+                [model], [expected_scenario], results_directory
+            )
+
+        self.assertEqual(results["runs"], 2)
+        self.assertEqual(results["models"][0]["baseline"]["runs"], 1)
+        self.assertEqual(results["models"][0]["skill"]["runs"], 1)
+
+    def test_report_handles_zero_violation_baselines(self):
+        model = "example/model:medium"
+        rows = [
+            self.make_raw_row(model, condition, "expected")
+            for condition in run_pi_bench.CONDITIONS
+        ]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            results_directory = pathlib.Path(temporary_directory)
+            raw_directory = results_directory / "raw"
+            raw_directory.mkdir()
+            for index, row in enumerate(rows):
+                (raw_directory / f"{index}.json").write_text(json.dumps(row))
+            results = run_pi_bench.aggregate_benchmark_results(
+                [model], [{"id": "expected"}], results_directory
+            )
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                run_pi_bench.write_benchmark_report(results, [model], results_directory)
+
+            report = (results_directory / "RESULTS.md").read_text()
+
+        self.assertIn("percentage reduction is undefined", report)
+
+    @staticmethod
+    def make_raw_row(model, condition, scenario_id):
+        return {
+            "model": model,
+            "condition": condition,
+            "scenario": scenario_id,
+            "duration_ms": 100,
+            "output_tokens": 10,
+            "reasoning_tokens": 2,
+            "cost_usd": 0,
+            "lint": {
+                "violations_per_100w": 0,
+                "violations_total": 0,
+                "words": 10,
+                "mean_sentence_words": 5,
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In case you want it, here are 4 more models in the Pi harness instead of Claude Code

- Add `evals/run_pi_bench.py` for isolated, resumable benchmarks through Pi.
- Add 64 raw generations and aggregate results for four models.
- Add a README cross-check and scope the shorter-output claim to the six Claude models that measured it.

## Results

| Model | Baseline viol/100w | Skill viol/100w | Reduction |
|---|---:|---:|---:|
| GLM-5.2 max | 2.56 | 0.40 | 84.4% |
| GPT-5.6 Sol medium | 1.33 | 0.16 | 88.0% |
| GPT-5.6 Terra medium | 1.69 | 0.48 | 71.6% |
| GPT-5.6 Luna medium | 1.28 | 0.42 | 67.2% |

The skill reduced the mean per-scenario linter score on all four models. Final text became shorter only on GLM-5.2; the three GPT-5.6 models wrote slightly more words.

The runner used a neutral system prompt. It disabled Pi tools, skills, prompt templates, extensions, context files, and session persistence. Each matrix cell has one generation. The run did not include a judge pass.

Full method, caveats, costs, reproduction command, and raw responses: [`evals/results/pi-2026-07-31/RESULTS.md`](https://github.com/Whamp/SimpleEnglish/blob/eval/pi-benchmark-results/evals/results/pi-2026-07-31/RESULTS.md)

## Validation

- `python3 -m unittest discover -s evals -p 'test_*.py'` — 7 tests passed
- `python3 evals/ste_lint.py --self-test` — passed
- `ruff format --check evals/run_pi_bench.py evals/test_run_pi_bench.py` — passed
- `ruff check evals/run_pi_bench.py evals/test_run_pi_bench.py` — passed
- `uvx ty check evals/run_pi_bench.py evals/test_run_pi_bench.py` — passed
- Fresh Luna smoke run — 4/4 generations, 0 failures
- Summary regeneration from committed raw files — byte-for-byte stable
