### PR TITLE
Guard against invented facts; align standalone prompt with the merged dictionary ruling

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -12,11 +12,11 @@ VERBS. Use only: infinitive, imperative, simple present, simple past, simple fut
 
 SENTENCES. Keep complete grammar: no contractions, keep articles, keep "that" ("make sure that the file exists"). Put conditions before commands, with a comma: "If the test fails, read the log." No semicolons — write two sentences. Use a vertical list for more than two items or steps.
 
-WORDS. One word, one meaning, for the whole document: pick one of check/verify/confirm and keep it. Noun chains of maximum three words; break longer ones with prepositions ("the timeout value for the connection pool"). Delete words that carry no fact: simply, seamlessly, robust, powerful, comprehensive, leverage, "in order to", "it is worth noting". Replace: utilize → use, prior to → before, in the event that → if, e.g. → for example. American spelling.
+WORDS. One word, one meaning, for the whole document: use "make sure that" for the check/verify/confirm concept, because the dictionary rejects all three as verbs. Noun chains of maximum three words; break longer ones with prepositions ("the timeout value for the connection pool"). Delete words that carry no fact: simply, seamlessly, robust, powerful, comprehensive, leverage, "in order to", "it is worth noting". Replace: utilize → use, prior to → before, in the event that → if, e.g. → for example. American spelling.
 
 WARNINGS. Command or condition first, then the risk: "Do not run this against production. The command deletes rows."
 
-NEVER TOUCH. Code blocks, identifiers, CLI commands, file paths, quoted error messages, product names. Each counts as one word toward sentence limits.
+NEVER TOUCH. Code blocks, identifiers, CLI commands, file paths, quoted error messages, product names. Each counts as one word toward sentence limits. Facts too: when the source does not give a number or a cause, keep the general statement — do not invent specifics.
 
 SELF-CHECK before returning: scan for contractions, "has been", "should", ", making", semicolons. Count words in your three longest sentences and split any over the limit. Collapse synonym rotation.
 

--- a/skills/simple-english/SKILL.md
+++ b/skills/simple-english/SKILL.md
@@ -289,6 +289,8 @@ These are technical names (Rules 1.5, 8.6). Leave them exact, even when they bre
 - Product names, API endpoint names, config keys
 - Numbers with units — each counts as one word in the sentence limit
 
+Facts are untouchable too. Rewrite the style, not the content. When the source does not give a number, a cause, or an exact term, keep the general statement. Do not invent specifics to look concrete.
+
 ## Beyond Documentation
 
 Same rules, different targets. Full adaptations in `references/use-cases.md`:


### PR DESCRIPTION
Rebased onto `main` after #5 landed. Docs-only, no behavior of the eval harness changes.

The two SKILL.md vocabulary hunks from the first version are **dropped**. #5 fixed both contradictions, and its dictionary-rulings table is the better fix — my wording ("verify and confirm are always safe") is wrong under the merged ruling. What is left:

## Guardrail: no invented facts

The before/after examples rewrite vague text into text with concrete values (an exact env var, a percentage, timestamps). That is the correct direction when the source gives those values. But a model that imitates the pattern without the source data invents them, and a clear, wrong instruction is more dangerous than a vague one. One paragraph in Untouchables and one line in the standalone prompt: specifics come only from the source; when the source gives no number or cause, keep the general statement.

## Leftover from #5: the standalone prompt

`prompts/system-prompt.md` still said "pick one of check/verify/confirm and keep it". #5 ruled all three rejected as verbs, but only in `SKILL.md`, so the condensed prompt now contradicts the skill it condenses. One line, now aligned on `make sure that`.

## Possible follow-up (not in this PR)

`ste_lint.py`'s `trailing_condition` fires on descriptive "when" clauses ("the service stops when the network fails"), which Rule 5.4 (condition before *command*) does not cover. In the published runs it is the one category where skill output scores worse than baseline. A fix changes the stored benchmark numbers, so it is a maintainer call — happy to send a separate PR if you want it.
