### PR TITLE
Add claude code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "simple-english",
+  "description": "ASD-STE100 Simplified Technical English skill for Claude Code.",
+  "owner": {
+    "name": "AminBlg",
+    "url": "https://github.com/AminBlg"
+  },
+  "plugins": [
+    {
+      "name": "simple-english",
+      "source": "./",
+      "description": "Write or rewrite technical text in ASD-STE100 Simplified Technical English, free of AI slop."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "simple-english",
+  "displayName": "Simple English",
+  "version": "1.0.0",
+  "description": "Write or rewrite technical text in ASD-STE100 Simplified Technical English: docs, READMEs, runbooks, error messages, release notes, and incident reports, free of AI slop.",
+  "author": {
+    "name": "AminBlg",
+    "url": "https://github.com/AminBlg"
+  },
+  "homepage": "https://github.com/AminBlg/SimpleEnglish",
+  "repository": "https://github.com/AminBlg/SimpleEnglish",
+  "license": "MIT",
+  "keywords": ["writing", "technical-writing", "documentation", "ste", "asd-ste100", "simplified-english"]
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ That is it. The [skills CLI](https://github.com/vercel-labs/skills) detects your
 npx skills use AminBlg/SimpleEnglish@simple-english
 ```
 
+**Claude Code plugin**: this repo is also a native [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces). Skip the CLI entirely:
+
+```
+/plugin marketplace add AminBlg/SimpleEnglish
+/plugin install simple-english@simple-english
+```
+
 No SKILL.md support at all? Paste [`prompts/system-prompt.md`](prompts/system-prompt.md) into your system prompt, AGENTS.md, or `.cursorrules`. There is even a ~60-token version for tight budgets.
 
 Then ask for any technical writing, or say: *"rewrite this with simple-english"*.


### PR DESCRIPTION
## Description

Adds native Claude Code plugin support so users can install this skill with `/plugin marketplace add` + `/plugin install` instead of going through the third-party `npx skills` CLI. This repo now doubles as a single-plugin Claude Code marketplace, alongside its existing agentskills.io SKILL.md distribution.

## Changes

- Add `.claude-plugin/plugin.json`: plugin manifest (name `simple-english`, metadata mirrors LICENSE/README). No `skills` path override needed, the existing `skills/simple-english/SKILL.md` layout is auto-discovered.
- Add `.claude-plugin/marketplace.json`: marketplace manifest listing the plugin with `source: "./"` (plugin lives at the repo root).
- Document the new install path in README's Install section, alongside the existing `npx skills add` instructions.

## Testing

Ran `claude plugin validate . --strict` (marketplace) and validated `plugin.json` standalone in an isolated temp copy. Both pass with no warnings. Also exercised the full user flow locally: `claude plugin marketplace add ./`, `claude plugin install simple-english@simple-english`, confirmed it shows up enabled in `claude plugin list`, then uninstalled and removed the test marketplace/cache entry to leave the environment clean.