### PR TITLE
Auto-load Simple English in Claude Code and Codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Simple English",
       "description": "Write or rewrite technical text with ASD-STE100 Simplified Technical English: short sentences, one word one meaning, active voice, condition before command.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "AminBlg"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,12 +2,26 @@
   "name": "simple-english",
   "displayName": "Simple English",
   "description": "Write or rewrite technical text with ASD-STE100 Simplified Technical English: short sentences, one word one meaning, active voice, condition before command.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "AminBlg"
   },
   "homepage": "https://github.com/AminBlg/SimpleEnglish",
   "repository": "https://github.com/AminBlg/SimpleEnglish",
   "license": "MIT",
-  "keywords": ["technical-writing", "documentation", "ste", "asd-ste100"]
+  "keywords": ["technical-writing", "documentation", "ste", "asd-ste100"],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/simple-english-activate.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading Simple English..."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "simple-english",
+  "version": "1.3.0",
+  "description": "Write or rewrite technical text with ASD-STE100 Simplified Technical English: short sentences, one word one meaning, active voice, condition before command.",
+  "author": {
+    "name": "AminBlg"
+  },
+  "homepage": "https://github.com/AminBlg/SimpleEnglish",
+  "repository": "https://github.com/AminBlg/SimpleEnglish",
+  "license": "MIT",
+  "keywords": ["technical-writing", "documentation", "ste", "asd-ste100"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Simple English",
+    "shortDescription": "Write clear technical text with ASD-STE100 rules.",
+    "longDescription": "Load Simplified Technical English rules automatically for documentation, procedures, error messages, runbooks, release notes, and incident reports.",
+    "developerName": "AminBlg",
+    "category": "Productivity",
+    "capabilities": ["Write"],
+    "websiteURL": "https://github.com/AminBlg/SimpleEnglish",
+    "defaultPrompt": [
+      "Rewrite this technical text in Simple English.",
+      "Write this procedure with ASD-STE100 rules.",
+      "Check this document for Simple English violations."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/STE_violations-%E2%88%9272.9%25_measured-brightgreen?style=flat" alt="72.9% fewer violations, measured"></a>
   <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/benchmarked_on-6_Claude_models-blueviolet?style=flat" alt="6 models benchmarked"></a>
   <a href="https://agentskills.io"><img src="https://img.shields.io/badge/SKILL.md-open_standard-blue?style=flat" alt="Agent Skills"></a>
-  <a href="skills/simple-english/SKILL.md"><img src="https://img.shields.io/badge/version-1.2.0-blue?style=flat" alt="version 1.2.0"></a>
+  <a href="skills/simple-english/SKILL.md"><img src="https://img.shields.io/badge/version-1.3.0-blue?style=flat" alt="version 1.3.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat" alt="MIT"></a>
   <a href="https://github.com/AminBlg/SimpleEnglish/stargazers"><img src="https://img.shields.io/github/stars/AminBlg/SimpleEnglish?style=flat&logo=github&color=yellow" alt="GitHub stars"></a>
 </p>
@@ -89,23 +89,56 @@ More rewrites in [`examples/before-after.md`](examples/before-after.md): READMEs
 
 ## 📦 Install
 
+Choose the installation that matches your agent:
+
+| Installation | Agents | Automatic session hook |
+|---|---|---|
+| Standalone skill | Cursor, Copilot, Gemini CLI, OpenCode, and other Agent Skills hosts | No |
+| Claude Code plugin | Claude Code | Yes |
+| Codex plugin | Codex CLI and Codex in the ChatGPT desktop app | Yes |
+
+The hook-enabled plugins require Node.js because the session hook runs a small Node script.
+
+### Standalone skill
+
 ```bash
 npx skills add AminBlg/SimpleEnglish
 ```
 
-That is it. The [skills CLI](https://github.com/vercel-labs/skills) detects your agents (Claude Code, Cursor, Codex, Copilot, Gemini CLI, and more) and installs for the ones you pick. Try before installing:
+The [skills CLI](https://github.com/vercel-labs/skills) detects your agents and installs the skill for the ones you pick. This method uses normal skill matching. It does not install the automatic session hook.
+
+Try the standalone skill before you install it:
 
 ```bash
 npx skills use AminBlg/SimpleEnglish@simple-english
 ```
 
-**Claude Code plugin**: this repo is also a plugin marketplace. From your terminal:
+### Claude Code plugin
+
+Install the plugin to get the skill and its automatic session hook:
 
 ```bash
 claude plugin marketplace add AminBlg/SimpleEnglish && claude plugin install simple-english@simple-english
 ```
 
 Or inside Claude Code: `/plugin marketplace add AminBlg/SimpleEnglish`, then `/plugin install simple-english@simple-english`.
+
+### Codex plugin
+
+Install the plugin to get the skill and its automatic session hook:
+
+```bash
+codex plugin marketplace add AminBlg/SimpleEnglish
+codex plugin add simple-english@simple-english
+```
+
+Or run `/plugins` in Codex CLI after you add the marketplace, then install **Simple English** from the `simple-english` tab.
+
+The Claude Code and Codex plugins load the skill automatically at session start. You do not need to name or invoke the skill. Its scope still limits the rules to technical-writing tasks.
+
+Codex asks you to review and trust the hook before its first run. Open `/hooks`, approve the Simple English hook, then start a new task.
+
+See [`src/hooks/README.md`](src/hooks/README.md) for details.
 
 **Output style** (Claude Code): the plugin also ships simple-english as an [output style](https://code.claude.com/docs/en/output-styles). The skill triggers when a writing task fits; the style is always on, for every reply. After you install the plugin, run `/config`, open **Output style**, and pick `simple-english`. Claude then writes all its prose in STE and codes as before.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,19 @@
+{
+  "description": "Load Simple English rules automatically for each Codex session.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "^(startup|resume|clear|compact)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/src/hooks/simple-english-activate.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading Simple English...",
+            "additionalContextLimit": 0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/simple-english/SKILL.md
+++ b/skills/simple-english/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simple-english
-version: 1.2.0
+version: 1.3.0
 description: |
   Write or rewrite technical text with the rules of ASD-STE100 Simplified
   Technical English so it is clear, unambiguous, and free of AI slop. Use for

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -1,0 +1,49 @@
+# Simple English Hooks
+
+The Claude Code and Codex plugins include a `SessionStart` hook. The hook loads the Simple English skill automatically when a session starts.
+
+Plugin users do not need to invoke the skill manually. Install the plugin, then start a new session.
+
+The hooks require Node.js. Both plugins run `src/hooks/simple-english-activate.js` with the `node` command.
+
+For Claude Code:
+
+```bash
+claude plugin marketplace add AminBlg/SimpleEnglish
+claude plugin install simple-english@simple-english
+```
+
+For Codex, install the full plugin instead of the standalone skill:
+
+```bash
+codex plugin marketplace add AminBlg/SimpleEnglish
+codex plugin add simple-english@simple-english
+```
+
+Codex asks you to review and trust the hook before its first run. Open `/hooks` to approve it.
+
+## How It Works
+
+The hook reads `skills/simple-english/SKILL.md`. It writes the skill body to standard output as hidden session context.
+
+It runs after startup, resume, clear, or context compaction. This behavior reloads the rules when the agent rebuilds its context.
+
+The skill file stays the source of truth. A change to the skill rules takes effect without a duplicate hook update.
+
+If the hook cannot find the skill file, it loads a small fallback ruleset. This fallback keeps the session usable and does not block startup.
+
+## Scope
+
+Automatic loading does not apply STE to all text. The scope in `SKILL.md` still controls when the agent uses the rules.
+
+Claude Code loads its hook from `.claude-plugin/plugin.json`. Codex loads its hook from `hooks/hooks.json` through `.codex-plugin/plugin.json`.
+
+The Codex hook uses `additionalContextLimit: 0`. This setting passes the complete skill to the model instead of the default truncated context.
+
+## Test
+
+Run this command from the repository root:
+
+```bash
+node --test src/hooks/simple-english-activate.test.js
+```

--- a/src/hooks/package.json
+++ b/src/hooks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/hooks/simple-english-activate.js
+++ b/src/hooks/simple-english-activate.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FALLBACK_CONTEXT = `SIMPLE ENGLISH SKILL ACTIVE AUTOMATICALLY
+
+Apply ASD-STE100 Simplified Technical English to technical-writing tasks. Use short sentences, active voice, one term for one meaning, and conditions before commands. Do not change code, identifiers, commands, or quoted errors.`;
+
+function skillCandidates(pluginRoot, hookDirectory) {
+  const candidates = [];
+
+  if (pluginRoot) {
+    candidates.push(path.join(pluginRoot, 'skills', 'simple-english', 'SKILL.md'));
+  }
+
+  candidates.push(
+    path.join(hookDirectory, '..', '..', 'skills', 'simple-english', 'SKILL.md'),
+    path.join(hookDirectory, '..', 'skills', 'simple-english', 'SKILL.md'),
+  );
+
+  return candidates;
+}
+
+function readFirstFile(candidates) {
+  for (const candidate of candidates) {
+    try {
+      return fs.readFileSync(candidate, 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') {
+        throw error;
+      }
+    }
+  }
+
+  return '';
+}
+
+function stripFrontmatter(content) {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}
+
+function buildContext(skillContent) {
+  if (!skillContent) {
+    return FALLBACK_CONTEXT;
+  }
+
+  return [
+    'SIMPLE ENGLISH SKILL ACTIVE AUTOMATICALLY',
+    '',
+    'Use the following skill without waiting for the user to name or invoke it. Keep its scope, modes, and exceptions authoritative.',
+    '',
+    stripFrontmatter(skillContent).trim(),
+  ].join('\n');
+}
+
+function main() {
+  const pluginRoot = process.env.PLUGIN_ROOT || process.env.CLAUDE_PLUGIN_ROOT;
+  const candidates = skillCandidates(pluginRoot, __dirname);
+  const skillContent = readFirstFile(candidates);
+  process.stdout.write(buildContext(skillContent));
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  FALLBACK_CONTEXT,
+  buildContext,
+  readFirstFile,
+  skillCandidates,
+  stripFrontmatter,
+};

--- a/src/hooks/simple-english-activate.test.js
+++ b/src/hooks/simple-english-activate.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  FALLBACK_CONTEXT,
+  buildContext,
+  readFirstFile,
+  skillCandidates,
+  stripFrontmatter,
+} = require('./simple-english-activate');
+
+test('prefers the skill in CLAUDE_PLUGIN_ROOT', () => {
+  const candidates = skillCandidates('/plugin', '/plugin/src/hooks');
+
+  assert.equal(candidates[0], '/plugin/skills/simple-english/SKILL.md');
+});
+
+test('accepts a Codex PLUGIN_ROOT', () => {
+  const candidates = skillCandidates('/codex-plugin', '/codex-plugin/src/hooks');
+
+  assert.equal(candidates[0], '/codex-plugin/skills/simple-english/SKILL.md');
+});
+
+test('supports a repository checkout without CLAUDE_PLUGIN_ROOT', () => {
+  const candidates = skillCandidates(undefined, '/repo/src/hooks');
+
+  assert.equal(candidates[0], '/repo/skills/simple-english/SKILL.md');
+});
+
+test('reads the first existing candidate', () => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'simple-english-hook-'));
+  const missing = path.join(temporaryDirectory, 'missing.md');
+  const existing = path.join(temporaryDirectory, 'SKILL.md');
+  fs.writeFileSync(existing, 'rules', 'utf8');
+
+  assert.equal(readFirstFile([missing, existing]), 'rules');
+});
+
+test('removes YAML frontmatter with LF or CRLF line endings', () => {
+  assert.equal(stripFrontmatter('---\nname: test\n---\nBody'), 'Body');
+  assert.equal(stripFrontmatter('---\r\nname: test\r\n---\r\nBody'), 'Body');
+});
+
+test('injects the canonical skill body into hidden session context', () => {
+  const context = buildContext('---\nname: simple-english\n---\n# Rules\nUse active voice.');
+
+  assert.match(context, /^SIMPLE ENGLISH SKILL ACTIVE AUTOMATICALLY/);
+  assert.match(context, /# Rules\nUse active voice\./);
+  assert.doesNotMatch(context, /name: simple-english/);
+});
+
+test('uses a safe minimum ruleset when the skill file is unavailable', () => {
+  assert.equal(buildContext(''), FALLBACK_CONTEXT);
+});


### PR DESCRIPTION
## Summary

- load the Simple English skill automatically at session start in Claude Code and Codex
- add a Codex plugin manifest and lifecycle hook configuration
- keep `skills/simple-english/SKILL.md` as the single source of truth
- document standalone-skill, Claude Code plugin, and Codex plugin installation separately
- bump plugin and skill metadata to `1.3.0`

## Why

The standalone skill relies on explicit or implicit skill selection. Users can therefore install Simple English without getting consistent activation in each session.

This change follows the SessionStart pattern used by the Caveman plugin. Plugin installs now inject the current Simple English rules as hidden session context. Users do not need to name or invoke the skill manually.

## Behavior

The shared Node hook reads the installed `SKILL.md`, removes its YAML frontmatter, and emits the complete skill body as session context.

- Claude Code registers the hook through `.claude-plugin/plugin.json`.
- Codex discovers `hooks/hooks.json` through `.codex-plugin/plugin.json`.
- Codex reloads the rules after startup, resume, clear, and context compaction.
- Codex uses `additionalContextLimit: 0` so the full skill is not truncated.
- If `SKILL.md` is unavailable, the hook emits a small fallback ruleset instead of blocking startup.
- The skill scope remains authoritative, so unrelated prose and code are not rewritten as STE.

Codex requires users to review and trust the plugin hook once through `/hooks`. Hook-enabled installs require Node.js.

## User impact

Users who want automatic activation install the full Claude Code or Codex plugin. The existing `npx skills add` path remains available for other Agent Skills hosts, but it does not install the hook.

The README now explains all three installation paths and their behavior.

## Validation

- `claude plugin validate .`
- Codex plugin validator
- `node --test src/hooks/simple-english-activate.test.js` — 7 passing tests
- `python3 -m unittest evals/test_run_pi_bench.py` — 7 passing tests
- isolated Claude Code marketplace and plugin installation
- isolated Codex marketplace and plugin installation
- `git diff --check`

## Release note

The manifests use version `1.3.0`. Because plugin clients cache versioned packages, the maintainer should keep this bump or choose another release version before merging.
