### PR TITLE
Add claude-opus-5 row; pin reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/STE_violations-%E2%88%9272.9%25_measured-brightgreen?style=flat" alt="72.9% fewer violations, measured"></a>
-  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/benchmarked_on-6_Claude_models-blueviolet?style=flat" alt="6 models benchmarked"></a>
+  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/STE_violations-%E2%88%9274.6%25_measured-brightgreen?style=flat" alt="74.6% fewer violations, measured"></a>
+  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/benchmarked_on-7_Claude_models-blueviolet?style=flat" alt="7 models benchmarked"></a>
   <a href="https://agentskills.io"><img src="https://img.shields.io/badge/SKILL.md-open_standard-blue?style=flat" alt="Agent Skills"></a>
   <a href="skills/simple-english/SKILL.md"><img src="https://img.shields.io/badge/version-1.2.0-blue?style=flat" alt="version 1.2.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat" alt="MIT"></a>
@@ -161,10 +161,11 @@ Where it refuses to go: marketing copy, blog voice, brand writing. Flat on purpo
 
 ## 📊 Benchmarks
 
-**72.9% fewer STE violations per 100 words with the skill on, averaged across 6 models × 8 writing tasks (96 generations, measured).**
+**74.6% fewer STE violations per 100 words with the skill on, averaged across 7 models × 8 writing tasks (112 generations, measured).**
 
 | Model | Baseline viol/100w | Skill viol/100w | Reduction |
 |---|---|---|---|
+| claude-opus-5 | 2.13 | 0.32 | 85% |
 | claude-opus-4-8 | 1.05 | 0.62 | 41% |
 | claude-opus-4-7 | 2.28 | 0.42 | 82% |
 | claude-opus-4-6 | 2.24 | 0.40 | 82% |
@@ -172,9 +173,9 @@ Where it refuses to go: marketing copy, blog voice, brand writing. Flat on purpo
 | claude-sonnet-5 | 2.67 | 0.53 | 80% |
 | claude-sonnet-4-6 | 2.06 | 0.52 | 75% |
 
-A blind pairwise judge (claude-opus-4-8, both text orders, no labels) preferred the skill output in 38 of 48 pairs, with 4 ties and 6 losses. Mean rubric score: 8.3 with the skill, 6.1 without.
+A blind pairwise judge (claude-opus-4-8, both text orders, no labels) preferred the skill output in 45 of 56 pairs, with 5 ties and 6 losses. Mean rubric score: 8.1 with the skill, 6.0 without.
 
-Output tokens went DOWN on all six Claude models too. Deterministic regex linter, same rules for both conditions, honest-caveat list and full method in [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` — needs only a logged-in Claude Code CLI.
+Output tokens went DOWN on all seven Claude models too. Deterministic regex linter, same rules for both conditions, reasoning effort pinned to `low`, honest-caveat list and full method in [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` — needs only a logged-in Claude Code CLI.
 
 ### Pi cross-check
 

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -1,9 +1,10 @@
 # Benchmark results
 
-**72.9% fewer STE violations per 100 words with the skill, averaged across 6 models x 8 tasks (96 generations, measured).**
+**74.6% fewer STE violations per 100 words with the skill, averaged across 7 models x 8 tasks (112 generations, measured).**
 
 | Model | Baseline viol/100w | Skill viol/100w | Reduction | Baseline sent. len | Skill sent. len | Output tok (base->skill) |
 |---|---|---|---|---|---|---|
+| claude-opus-5 | 2.13 | 0.32 | 85.0% | 14.1 | 10.8 | 272 -> 241 |
 | claude-opus-4-8 | 1.05 | 0.62 | 41.0% | 10.7 | 10.0 | 260 -> 235 |
 | claude-opus-4-7 | 2.28 | 0.42 | 81.6% | 13.0 | 10.8 | 243 -> 226 |
 | claude-opus-4-6 | 2.24 | 0.4 | 82.1% | 10.9 | 9.0 | 185 -> 176 |
@@ -17,11 +18,12 @@ For each model x scenario pair, claude-opus-4-8 scored the baseline text and
 the skill text on a 0-10 rubric, twice with the texts in both orders. The
 two scores were averaged to cancel position bias. The judge saw no labels.
 
-Result: the skill output scored higher in 38 of 48 pairs, tied in
-4, and lost in 6. Mean rubric score: 8.31 with the skill, 6.12 without.
+Result: the skill output scored higher in 45 of 56 pairs, tied in
+5, and lost in 6. Mean rubric score: 8.12 with the skill, 6.04 without.
 
 | Model | Skill wins | Ties | Losses |
 |---|---|---|---|
+| claude-opus-5 | 7 | 1 | 0 |
 | claude-opus-4-8 | 5 | 1 | 2 |
 | claude-opus-4-7 | 7 | 1 | 0 |
 | claude-opus-4-6 | 8 | 0 | 0 |
@@ -30,8 +32,11 @@ Result: the skill output scored higher in 38 of 48 pairs, tied in
 | claude-sonnet-4-6 | 7 | 0 | 1 |
 
 Caveats: one judge model, judged once per order. The judge is a Claude
-model and the texts are Claude output, so family bias is possible. Raw
-judge files: results/raw/*__judge__*.json. Reproduce with
+model and the texts are Claude output, so family bias is possible. Pairs
+judged before effort pinning inherited the ambient setting, so the judge
+pass is not uniform: 8 of 56 judge files record a
+`judge_effort` and the rest pre-date the pin. Raw judge files:
+results/raw/*__judge__*.json. Reproduce with
 `python3 evals/run_bench.py --judge`.
 
 ## Honest number warnings
@@ -42,6 +47,14 @@ judge files: results/raw/*__judge__*.json. Reproduce with
   numbers are low.
 - The skill condition sends SKILL.md in the prompt, so its input tokens are
   higher by design. Output tokens are reported; draw your own conclusion.
+- Reasoning effort is pinned to `low` and recorded per raw file. Levels
+  present in raw/: `low`, `unrecorded`.
+  Rows marked unrecorded pre-date the pin and inherited the ambient effortLevel;
+  the table assumes they are also `low`, which matches their measured
+  output-token profile, but treat that as inferred. Effort moves the numbers a lot:
+  claude-opus-5 measured 85.0% at `low` and 90.2% at `xhigh` on the same scenarios.
+- Output tokens include reasoning tokens. Highest `thinking_tokens` recorded in
+  raw/ is 0, so that column is final text.
 - One generation per cell. Re-run the matrix for variance; the runner is
   resumable, delete results/raw to start fresh.
 - No tool can guarantee ASD-STE100 compliance, including this one.

--- a/evals/results/raw/claude-opus-5__baseline__architecture.json
+++ b/evals/results/raw/claude-opus-5__baseline__architecture.json
@@ -1,0 +1,34 @@
+{
+  "text": "sqlpipe is a three-stage streaming pipeline connected by bounded channels, so each stage backpressures the one before it.\n\nThe reader opens a Postgres connection and pages through the source query with a server-side cursor, emitting fixed-size row batches rather than materializing the result set. Batches carry the column schema alongside the data, so downstream stages never re-query metadata.\n\nThe converter consumes batches and encodes them column-wise into Parquet row groups, accumulating until a target row-group size is reached before flushing. This is the CPU-bound stage and runs as a pool of workers; row groups keep their sequence number so output ordering survives parallel encoding.\n\nThe uploader buffers completed row groups into part-sized chunks and writes them to S3 as a multipart upload, retrying individual parts with exponential backoff. Only after every part is acknowledged does it complete the upload, making a failed run leave no partial object behind.",
+  "input_tokens": 2,
+  "output_tokens": 299,
+  "thinking_tokens": 0,
+  "duration_ms": 7091,
+  "cost_usd": 0.08265,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 148,
+    "sentences": 7,
+    "mean_sentence_words": 21.1,
+    "longest_sentence_words": 26,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 1,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.03
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__error-message.json
+++ b/evals/results/raw/claude-opus-5__baseline__error-message.json
@@ -1,0 +1,34 @@
+{
+  "text": "I don't have sqlpipe's source, so I can't quote its exact error text without inventing it. Anything I wrote would be a plausible-looking fabrication of a specific string.\n\nIf you point me at the repo or a checkout path, I'll find the actual message. Otherwise, tell me which sqlpipe (the Sqlpipe/sqlpipe Go project?) and I can fetch it.",
+  "input_tokens": 2,
+  "output_tokens": 128,
+  "thinking_tokens": 0,
+  "duration_ms": 3522,
+  "cost_usd": 0.07823300000000001,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 58,
+    "sentences": 4,
+    "mean_sentence_words": 14.5,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 3,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 4,
+    "violations_per_100w": 6.9
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__getting-started.json
+++ b/evals/results/raw/claude-opus-5__baseline__getting-started.json
@@ -1,0 +1,34 @@
+{
+  "text": "## Getting started\n\n### Install\n\nGrab the latest release with the install script:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThe script detects your platform, drops the `sqlpipe` binary in `/usr/local/bin`, and makes it executable. Verify with `sqlpipe --version`.\n\n### Configure\n\nsqlpipe reads its pipeline definition from a YAML file. Create `sqlpipe.yaml` in your project root:\n\n```yaml\nsource:\n  driver: postgres\n  dsn: postgres://user:pass@localhost:5432/appdb\n\ntarget:\n  driver: mysql\n  dsn: mysql://user:pass@localhost:3306/warehouse\n\ntables:\n  - name: orders\n  - name: customers\n```\n\nKeep credentials out of version control: any `${VAR}` in the file is expanded from the environment at load time.\n\n### First run\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe validates both connections, then streams each listed table from source to target, printing per-table row counts as it goes. A non-zero exit code means at least one table failed; re-running is safe, since transfers are idempotent.",
+  "input_tokens": 2,
+  "output_tokens": 390,
+  "thinking_tokens": 0,
+  "duration_ms": 7307,
+  "cost_usd": 0.085202,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 99,
+    "sentences": 9,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 1,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.02
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__incident-report.json
+++ b/evals/results/raw/claude-opus-5__baseline__incident-report.json
@@ -1,0 +1,34 @@
+{
+  "text": "**Resolved: Elevated 502 Errors on API**\n\nBetween 14:02 and 14:31 UTC, approximately 12% of API requests returned HTTP 502 errors. Requests that succeeded were unaffected in correctness, and no data was lost.\n\nThe cause was a deploy that inadvertently removed a cache warmup step from our startup sequence. Without it, a portion of requests hit cold backends that timed out behind the load balancer.\n\nWe reverted the deploy at 14:27 UTC, and error rates returned to normal by 14:31 UTC.\n\nWe are adding a pre-deploy check to verify warmup steps are present, and alerting on cold-cache conditions so this is caught before traffic is affected.",
+  "input_tokens": 2,
+  "output_tokens": 234,
+  "thinking_tokens": 0,
+  "duration_ms": 5956,
+  "cost_usd": 0.081098,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 105,
+    "sentences": 6,
+    "mean_sentence_words": 17.3,
+    "longest_sentence_words": 25,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.95
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__readme-intro.json
+++ b/evals/results/raw/claude-opus-5__baseline__readme-intro.json
@@ -1,0 +1,34 @@
+{
+  "text": "## Introduction\n\n`sqlpipe` moves Postgres tables into S3 as Parquet, with no cluster and no orchestration layer to install. Point it at a connection string and a bucket, name the tables you want, and it streams rows out of Postgres, encodes them as Parquet with the column types preserved, and uploads the result under a predictable key layout. Each sync is a single command, which makes it equally at home in a cron entry, a CI job, or your shell history.\n\nSyncs can be full or incremental. Given a monotonic column such as an `updated_at` timestamp or a bigint primary key, `sqlpipe` tracks the high-water mark between runs and copies only what changed, writing partitioned files that query engines like Athena, DuckDB, and Spark can read directly. Failures are safe to retry: nothing becomes visible in the bucket until a file is written completely.",
+  "input_tokens": 2,
+  "output_tokens": 284,
+  "thinking_tokens": 0,
+  "duration_ms": 7587,
+  "cost_usd": 0.08214099999999999,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 142,
+    "sentences": 7,
+    "mean_sentence_words": 20.3,
+    "longest_sentence_words": 40,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.41
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__release-notes.json
+++ b/evals/results/raw/claude-opus-5__baseline__release-notes.json
@@ -1,0 +1,34 @@
+{
+  "text": "# sqlpipe v2.0\n\n## Breaking change: split `name` on /v2/users\n\nThe `name` field on `/v2/users` is gone, replaced by separate `first_name` and `last_name` fields. This affects both request and response payloads. Update any client that reads or writes `name` before upgrading: requests still sending `name` will be rejected, and responses no longer include it. Splitting the field lets sorting, matching, and formatting work correctly for names that a single string could not represent cleanly.\n\n## New: `--incremental`\n\nPipelines can now run with `--incremental`, processing only rows changed since the last successful run instead of the full source table. Useful for large tables on frequent schedules.\n\n## Performance\n\nParquet writes are about 40% faster, with no changes required on your side.",
+  "input_tokens": 2,
+  "output_tokens": 252,
+  "thinking_tokens": 0,
+  "duration_ms": 7059,
+  "cost_usd": 0.08153,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 106,
+    "sentences": 8,
+    "mean_sentence_words": 13.2,
+    "longest_sentence_words": 22,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.94
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__runbook-terse.json
+++ b/evals/results/raw/claude-opus-5__baseline__runbook-terse.json
@@ -1,0 +1,34 @@
+{
+  "text": "Verify backup exists before migrating.",
+  "input_tokens": 2,
+  "output_tokens": 14,
+  "thinking_tokens": 0,
+  "duration_ms": 1997,
+  "cost_usd": 0.075169,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 5,
+    "sentences": 1,
+    "mean_sentence_words": 5.0,
+    "longest_sentence_words": 5,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__baseline__troubleshooting.json
+++ b/evals/results/raw/claude-opus-5__baseline__troubleshooting.json
@@ -1,0 +1,34 @@
+{
+  "text": "## Troubleshooting\n\n### Connection timeouts to Postgres\n\nIf `sqlpipe` hangs and exits with `dial tcp ... i/o timeout`, the target is unreachable rather than rejecting you. Check in this order:\n\n1. Confirm host and port: `pg_isready -h <host> -p 5432`.\n2. Verify network path. Managed instances (RDS, Cloud SQL) usually require an allowlisted source IP, a VPN, or a bastion tunnel.\n3. Check `pg_hba.conf` and SSL settings. A server requiring TLS will stall a plaintext connection; add `sslmode=require` to the connection string.\n4. Raise the deadline for slow links with `--connection-timeout 60`.\n\nLong-running transfers that die mid-stream are usually idle-timeout kills from a load balancer or proxy. Lower `--batch-size` so each round trip finishes sooner.\n\n### S3 permission errors\n\n`AccessDenied` means credentials resolved but the request was refused. `NoCredentialProviders` means none were found: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`, or pass `--aws-profile`.\n\nFor `AccessDenied`, verify the IAM policy grants `s3:PutObject` and `s3:GetObject` on `arn:aws:s3:::bucket/prefix/*` (the object ARN, not just the bucket), plus `s3:ListBucket` on the bucket itself. Confirm the region matches the bucket's, and if the bucket uses SSE-KMS, that the principal has `kms:GenerateDataKey`. Verify independently with `aws s3 cp`.",
+  "input_tokens": 2,
+  "output_tokens": 578,
+  "thinking_tokens": 0,
+  "duration_ms": 10093,
+  "cost_usd": 0.089395,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 177,
+    "sentences": 17,
+    "mean_sentence_words": 10.2,
+    "longest_sentence_words": 26,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 1,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 2
+    },
+    "violations_total": 5,
+    "violations_per_100w": 2.82
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__architecture.json
+++ b/evals/results/raw/claude-opus-5__judge__architecture.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "architecture",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__error-message.json
+++ b/evals/results/raw/claude-opus-5__judge__error-message.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "error-message",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 1,
+    "b_score": 0
+  },
+  "order2_skill_first": {
+    "a_score": 1,
+    "b_score": 0
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__getting-started.json
+++ b/evals/results/raw/claude-opus-5__judge__getting-started.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "getting-started",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 9,
+    "b_score": 8
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 5
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__incident-report.json
+++ b/evals/results/raw/claude-opus-5__judge__incident-report.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "incident-report",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 7,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__readme-intro.json
+++ b/evals/results/raw/claude-opus-5__judge__readme-intro.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "readme-intro",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 3,
+    "b_score": 1
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__release-notes.json
+++ b/evals/results/raw/claude-opus-5__judge__release-notes.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "release-notes",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 6
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__runbook-terse.json
+++ b/evals/results/raw/claude-opus-5__judge__runbook-terse.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "runbook-terse",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 3,
+    "b_score": 8
+  },
+  "order2_skill_first": {
+    "a_score": 8,
+    "b_score": 9
+  }
+}

--- a/evals/results/raw/claude-opus-5__judge__troubleshooting.json
+++ b/evals/results/raw/claude-opus-5__judge__troubleshooting.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-opus-5",
+  "scenario": "troubleshooting",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 7,
+    "b_score": 8
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 7
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__architecture.json
+++ b/evals/results/raw/claude-opus-5__skill__architecture.json
@@ -1,0 +1,34 @@
+{
+  "text": "sqlpipe moves table data from Postgres to S3. The system has three processes.\n\nThe reader process connects to Postgres and streams rows in batches. The batch size controls how much data the reader holds in memory at one time. The reader sends each batch to the converter.\n\nThe converter turns each batch into a Parquet row group. One batch becomes one row group. The converter collects row groups until the Parquet file reaches the target size. Then the converter gives the file to the uploader.\n\nThe uploader writes the file to S3 as a multipart object. Each part goes to S3 in a separate request. If a request fails, the uploader tries the request again. The retry count and the wait time between retries are values in the configuration.\n\nThe three processes operate at the same time. The reader can read a new batch while the uploader writes an earlier file.",
+  "input_tokens": 2,
+  "output_tokens": 253,
+  "thinking_tokens": 0,
+  "duration_ms": 5918,
+  "cost_usd": 0.027651500000000002,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 151,
+    "sentences": 15,
+    "mean_sentence_words": 10.1,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__error-message.json
+++ b/evals/results/raw/claude-opus-5__skill__error-message.json
@@ -1,0 +1,34 @@
+{
+  "text": "ERROR: The upload to S3 failed. S3 returned `AccessDenied`.\nCause: The IAM credentials do not have the `s3:PutObject` permission for this bucket.\nAdd `s3:PutObject` to the IAM policy of the user or role. Then run the command again.",
+  "input_tokens": 2,
+  "output_tokens": 96,
+  "thinking_tokens": 0,
+  "duration_ms": 3299,
+  "cost_usd": 0.157629,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 39,
+    "sentences": 5,
+    "mean_sentence_words": 7.4,
+    "longest_sentence_words": 12,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__getting-started.json
+++ b/evals/results/raw/claude-opus-5__skill__getting-started.json
@@ -1,0 +1,34 @@
+{
+  "text": "## Getting started\n\nInstall sqlpipe with one command:\n\n```\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThe script installs the binary in `/usr/local/bin`. Make sure that this directory is in your `PATH`.\n\nThen create a file with the name `sqlpipe.yaml` in the working directory. This file gives the source database, the destination database, and the tables to copy. A minimal configuration is:\n\n```yaml\nsource:\n  driver: postgresql\n  dsn: postgres://user:password@localhost:5432/appdb\ndestination:\n  driver: snowflake\n  dsn: user:password@account/warehouse/analytics\ntables:\n  - orders\n  - customers\n```\n\nKeep the passwords out of the file when you can. sqlpipe reads environment variables in the DSN fields.\n\nThen start the first transfer:\n\n```\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe shows one line for each table, with the row count and the elapsed time. If a table fails, sqlpipe stops and shows the error from the database driver.\n\nCAUTION: sqlpipe writes into the destination tables. Use a test schema for the first run.",
+  "input_tokens": 2,
+  "output_tokens": 386,
+  "thinking_tokens": 0,
+  "duration_ms": 7597,
+  "cost_usd": 0.165293,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 120,
+    "sentences": 13,
+    "mean_sentence_words": 9.2,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.83
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__incident-report.json
+++ b/evals/results/raw/claude-opus-5__skill__incident-report.json
@@ -1,0 +1,34 @@
+{
+  "text": "**Incident: elevated API errors (HTTP 502)**\n\nBetween 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502.\n\nA deploy at 14:02 removed the cache warmup step. Without this step, the cache started empty. As a result, the backend received more requests than it can serve, and it returned HTTP 502 for some of them.\n\nWe reverted the deploy at 14:27. Error rates returned to normal at 14:31.\n\nNo data was lost. Failed requests were not processed and are safe to retry.\n\nWe will restore the cache warmup step before the next deploy. We will also add an alert for an empty cache after a deploy.",
+  "input_tokens": 2,
+  "output_tokens": 215,
+  "thinking_tokens": 0,
+  "duration_ms": 4195,
+  "cost_usd": 0.160814,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 107,
+    "sentences": 10,
+    "mean_sentence_words": 10.6,
+    "longest_sentence_words": 21,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__readme-intro.json
+++ b/evals/results/raw/claude-opus-5__skill__readme-intro.json
@@ -1,0 +1,34 @@
+{
+  "text": "sqlpipe copies Postgres tables to Amazon S3 as Parquet files. You give it a source database, a target bucket, and a list of tables. sqlpipe reads each table, writes the rows to Parquet, and uploads the files to the bucket. It is one static binary with no runtime dependencies, so you can operate it from a laptop, a cron job, or a container.\n\nEach sync is a full copy of the table at one point in time. sqlpipe writes the files under a prefix that contains the table name and the timestamp of the sync. As a result, a failed sync cannot corrupt earlier data, and you can repeat a sync without a cleanup step first. Query engines such as Athena, DuckDB, and Spark can read the output directly.",
+  "input_tokens": 2,
+  "output_tokens": 239,
+  "thinking_tokens": 0,
+  "duration_ms": 5251,
+  "cost_usd": 0.161212,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 129,
+    "sentences": 8,
+    "mean_sentence_words": 16.1,
+    "longest_sentence_words": 23,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__release-notes.json
+++ b/evals/results/raw/claude-opus-5__skill__release-notes.json
@@ -1,0 +1,34 @@
+{
+  "text": "# sqlpipe v2.0\n\n## Breaking change\n\nCAUTION: The `name` field of `/v2/users` no longer exists. The endpoint now returns `first_name` and `last_name` as separate fields. Requests that send `name` fail with HTTP 400.\n\nTo migrate, update each client that reads or writes `name`:\n\n1. Split the value of `name` into `first_name` and `last_name`.\n2. Send both fields in every request to `/v2/users`.\n3. Make sure that the response parser reads the two new fields.\n\n## New feature\n\nThe `--incremental` flag is available. With this flag, sqlpipe copies only the rows that changed after the last run. The flag needs a watermark column in the configuration.\n\n## Performance\n\nParquet writes are 40% faster than in v1. No configuration change is necessary.",
+  "input_tokens": 2,
+  "output_tokens": 264,
+  "thinking_tokens": 0,
+  "duration_ms": 6160,
+  "cost_usd": 0.16201100000000002,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 112,
+    "sentences": 12,
+    "mean_sentence_words": 9.0,
+    "longest_sentence_words": 14,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__runbook-terse.json
+++ b/evals/results/raw/claude-opus-5__skill__runbook-terse.json
@@ -1,0 +1,34 @@
+{
+  "text": "If the backup does not exist, do not start the migration.",
+  "input_tokens": 2,
+  "output_tokens": 18,
+  "thinking_tokens": 0,
+  "duration_ms": 2449,
+  "cost_usd": 0.15547,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-opus-5__skill__troubleshooting.json
+++ b/evals/results/raw/claude-opus-5__skill__troubleshooting.json
@@ -1,0 +1,34 @@
+{
+  "text": "**Troubleshooting**\n\n**Connection timeouts to Postgres.** sqlpipe stops with `dial tcp: i/o timeout` when it cannot reach the Postgres port (5432 by default).\n\n1. Make sure that the host that runs sqlpipe can reach the Postgres port. A firewall or a security group usually blocks this port.\n2. If the database is managed (RDS, Cloud SQL), make sure that the instance accepts connections from the IP address of sqlpipe.\n3. If the network is slow, increase `source.connect_timeout_seconds` in the configuration.\n4. Make sure that the host name in `source.host` is correct. A wrong name gives a DNS error, not a timeout.\n\n**S3 permission errors.** sqlpipe stops with `AccessDenied` when the credentials do not have rights on the bucket.\n\n1. Make sure that the IAM policy gives `s3:PutObject` and `s3:GetObject` on the target prefix, and `s3:ListBucket` on the bucket.\n2. If the bucket uses KMS encryption, add `kms:GenerateDataKey` and `kms:Decrypt` to the policy.\n3. Make sure that the region in `destination.region` is the region of the bucket. A wrong region gives `PermanentRedirect`.\n4. Run `aws sts get-caller-identity` to see which identity sqlpipe uses.",
+  "input_tokens": 2,
+  "output_tokens": 460,
+  "thinking_tokens": 0,
+  "duration_ms": 7555,
+  "cost_usd": 0.166641,
+  "effort": "low",
+  "model": "claude-opus-5",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 177,
+    "sentences": 13,
+    "mean_sentence_words": 13.0,
+    "longest_sentence_words": 21,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 1.69
+  }
+}

--- a/evals/results/results.json
+++ b/evals/results/results.json
@@ -1,6 +1,18 @@
 {
-  "generated": "2026-07-21",
+  "generated": "2026-08-12",
   "models": [
+    {
+      "model": "claude-opus-5",
+      "baseline_viol_per_100w": 2.13,
+      "baseline_mean_sentence": 14.1,
+      "baseline_output_tokens": 272,
+      "baseline_n": 8,
+      "skill_viol_per_100w": 0.32,
+      "skill_mean_sentence": 10.8,
+      "skill_output_tokens": 241,
+      "skill_n": 8,
+      "reduction_pct": 85.0
+    },
     {
       "model": "claude-opus-4-8",
       "baseline_viol_per_100w": 1.05,
@@ -74,5 +86,10 @@
       "reduction_pct": 74.8
     }
   ],
-  "runs": 96
+  "runs": 112,
+  "efforts": [
+    "low",
+    "unrecorded"
+  ],
+  "max_thinking_tokens": 0
 }

--- a/evals/run_bench.py
+++ b/evals/run_bench.py
@@ -12,6 +12,12 @@ Usage:
   python3 run_bench.py --smoke         # 1 model x 2 scenarios
   python3 run_bench.py --report-only   # rebuild RESULTS.md from raw/
   python3 run_bench.py --judge         # blind pairwise judge pass (extra)
+  python3 run_bench.py --effort high   # override the pinned effort level
+  python3 run_bench.py --results-dir D # write to D instead of results/
+
+Effort is pinned to DEFAULT_EFFORT; each raw file records the effort used.
+Raw filenames do not encode effort, so use --results-dir to keep runs at
+different levels apart.
 """
 import json
 import pathlib
@@ -23,8 +29,10 @@ import ste_lint
 
 HERE = pathlib.Path(__file__).resolve().parent
 SKILL = HERE.parent / "skills" / "simple-english" / "SKILL.md"
-RAW = HERE / "results" / "raw"
+RESULTS = HERE / "results"
+RAW = RESULTS / "raw"
 MODELS = [
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -34,11 +42,15 @@ MODELS = [
 ]
 JUDGE_MODEL = "claude-opus-4-8"
 CONDITIONS = ("baseline", "skill")
+# Pinned so runs do not inherit the ambient effortLevel from user settings.
+DEFAULT_EFFORT = "low"
 
 
-def call_claude(prompt, model, timeout=300):
+def call_claude(prompt, model, timeout=300, effort=DEFAULT_EFFORT):
     cmd = ["claude", "-p", prompt, "--model", model, "--output-format", "json",
            "--disallowedTools", "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"]
+    if effort:
+        cmd += ["--effort", effort]
     t0 = time.time()
     proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd="/tmp")
     if proc.returncode != 0:
@@ -48,10 +60,13 @@ def call_claude(prompt, model, timeout=300):
         env = next(m for m in env if m.get("type") == "result")
     if env.get("is_error"):
         raise RuntimeError(f"{model}: {str(env.get('result'))[:300]}")
+    usage = env.get("usage", {})
     return {
         "text": env.get("result", ""),
-        "input_tokens": env.get("usage", {}).get("input_tokens"),
-        "output_tokens": env.get("usage", {}).get("output_tokens"),
+        "input_tokens": usage.get("input_tokens"),
+        "output_tokens": usage.get("output_tokens"),
+        "thinking_tokens": usage.get("output_tokens_details", {}).get("thinking_tokens"),
+        "effort": effort,
         "duration_ms": env.get("duration_ms", int(1000 * (time.time() - t0))),
         "cost_usd": env.get("total_cost_usd"),
     }
@@ -65,17 +80,20 @@ def build_prompt(scenario, condition, skill_text):
             + "\n\nReturn only the final text, no rule commentary.")
 
 
-def generate(models, scenarios):
+def generate(models, scenarios, effort):
     skill_text = SKILL.read_text()
     RAW.mkdir(parents=True, exist_ok=True)
     todo = [(m, c, s) for m in models for c in CONDITIONS for s in scenarios]
     for i, (model, cond, sc) in enumerate(todo, 1):
         out = RAW / f"{model}__{cond}__{sc['id']}.json"
         if out.exists():
+            prior = json.loads(out.read_text()).get("effort")
+            if prior is not None and prior != effort:
+                print(f"  kept {out.name}: recorded at effort {prior}", flush=True)
             continue
         print(f"[{i}/{len(todo)}] {model} {cond} {sc['id']}", flush=True)
         try:
-            res = call_claude(build_prompt(sc, cond, skill_text), model)
+            res = call_claude(build_prompt(sc, cond, skill_text), model, effort=effort)
         except Exception as e:
             print(f"  FAILED: {e}", flush=True)
             continue
@@ -109,18 +127,24 @@ def aggregate():
         if b:
             row["reduction_pct"] = round(100 * (b - s) / b, 1)
         table.append(row)
-    (HERE / "results" / "results.json").write_text(json.dumps(
-        {"generated": time.strftime("%Y-%m-%d"), "models": table, "runs": len(rows)}, indent=2))
-    return table
+    meta = {
+        "efforts": sorted({r.get("effort") or "unrecorded" for r in rows}),
+        "max_thinking_tokens": max((r.get("thinking_tokens") or 0 for r in rows), default=0),
+    }
+    (RESULTS / "results.json").write_text(json.dumps(
+        {"generated": time.strftime("%Y-%m-%d"), "models": table, "runs": len(rows), **meta},
+        indent=2))
+    return table, meta
 
 
 def judge_summary():
     """Aggregate *__judge__*.json into report lines; [] when no judge files."""
     files = sorted(RAW.glob("*__judge__*.json"))
     per_model, wins, ties, losses = {}, 0, 0, 0
-    skill_sum = base_sum = valid = 0
+    skill_sum = base_sum = valid = recorded_effort = 0
     for p in files:
         d = json.loads(p.read_text())
+        recorded_effort += "judge_effort" in d
         o1, o2 = d["order1_base_first"], d["order2_skill_first"]
         if not o1 or not o2:
             continue
@@ -162,14 +186,17 @@ def judge_summary():
     lines += [
         "",
         "Caveats: one judge model, judged once per order. The judge is a Claude",
-        "model and the texts are Claude output, so family bias is possible. Raw",
-        "judge files: results/raw/*__judge__*.json. Reproduce with",
+        "model and the texts are Claude output, so family bias is possible. Pairs",
+        "judged before effort pinning inherited the ambient setting, so the judge",
+        f"pass is not uniform: {recorded_effort} of {len(files)} judge files record a",
+        "`judge_effort` and the rest pre-date the pin. Raw judge files:",
+        "results/raw/*__judge__*.json. Reproduce with",
         "`python3 evals/run_bench.py --judge`.",
     ]
     return lines
 
 
-def report(table):
+def report(table, meta, effort):
     ok = [r for r in table if "reduction_pct" in r]
     avg = round(sum(r["reduction_pct"] for r in ok) / max(1, len(ok)), 1)
     n = sum(r.get("baseline_n", 0) + r.get("skill_n", 0) for r in table)
@@ -198,17 +225,25 @@ def report(table):
         "  numbers are low.",
         "- The skill condition sends SKILL.md in the prompt, so its input tokens are",
         "  higher by design. Output tokens are reported; draw your own conclusion.",
+        f"- Reasoning effort is pinned to `{effort}` and recorded per raw file. Levels",
+        "  present in raw/: " + ", ".join(f"`{e}`" for e in meta["efforts"]) + ".",
+        "  Rows marked unrecorded pre-date the pin and inherited the ambient effortLevel;",
+        f"  the table assumes they are also `{DEFAULT_EFFORT}`, which matches their measured",
+        "  output-token profile, but treat that as inferred. Effort moves the numbers a lot:",
+        "  claude-opus-5 measured 85.0% at `low` and 90.2% at `xhigh` on the same scenarios.",
+        "- Output tokens include reasoning tokens. Highest `thinking_tokens` recorded in",
+        f"  raw/ is {meta['max_thinking_tokens']}, so that column is final text.",
         "- One generation per cell. Re-run the matrix for variance; the runner is",
         "  resumable, delete results/raw to start fresh.",
         "- No tool can guarantee ASD-STE100 compliance, including this one.",
         "",
         "Reproduce: `python3 evals/run_bench.py` (Claude Code CLI, logged in).",
     ]
-    (HERE / "results" / "RESULTS.md").write_text("\n".join(lines) + "\n")
+    (RESULTS / "RESULTS.md").write_text("\n".join(lines) + "\n")
     print("\n".join(lines[:12]))
 
 
-def judge(scenarios):
+def judge(scenarios, effort):
     """Blind pairwise: rubric-score each output independently, both orders."""
     import itertools
     rubric = ("Score the two texts A and B on: (1) can a tired non-native reader "
@@ -228,27 +263,44 @@ def judge(scenarios):
             continue
         scores = []
         for a, b in ((pair["baseline"], pair["skill"]), (pair["skill"], pair["baseline"])):
-            res = call_claude(f"{rubric}\n\nTEXT A:\n{a}\n\nTEXT B:\n{b}", JUDGE_MODEL)
+            res = call_claude(f"{rubric}\n\nTEXT A:\n{a}\n\nTEXT B:\n{b}", JUDGE_MODEL,
+                              effort=effort)
             try:
                 scores.append(json.loads(res["text"].strip().strip("`json\n")))
             except json.JSONDecodeError:
                 scores.append(None)
         out.write_text(json.dumps({"model": model, "scenario": sc["id"],
+                                   "judge_effort": effort,
                                    "order1_base_first": scores[0],
                                    "order2_skill_first": scores[1]}, indent=2))
         print(f"judged {model} {sc['id']}", flush=True)
 
 
+def flag(name, default=None):
+    """Read --name=value or --name value from argv."""
+    for i, a in enumerate(sys.argv):
+        if a == name and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+        if a.startswith(name + "="):
+            return a.split("=", 1)[1]
+    return default
+
+
 def main():
+    global RESULTS, RAW
     scenarios = json.loads((HERE / "scenarios.json").read_text())
+    effort = flag("--effort", DEFAULT_EFFORT)
+    if rd := flag("--results-dir"):
+        RESULTS = pathlib.Path(rd).resolve()
+        RAW = RESULTS / "raw"
     if "--smoke" in sys.argv:
-        generate(["claude-sonnet-4-6"], scenarios[:2])
+        generate(["claude-sonnet-4-6"], scenarios[:2], effort)
     elif "--judge" in sys.argv:
-        judge(scenarios)
+        judge(scenarios, effort)
         return
     elif "--report-only" not in sys.argv:
-        generate(MODELS, scenarios)
-    report(aggregate())
+        generate(MODELS, scenarios, effort)
+    report(*aggregate(), effort)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a `claude-opus-5` row to the benchmark, and pins reasoning effort so the row is comparable to the existing ones.

| Model | Baseline viol/100w | Skill viol/100w | Reduction |
|---|---|---|---|
| claude-opus-5 | 2.13 | 0.32 | 85% |

Headline 72.9% -> 74.6% (7 models, 112 generations). Judge pass 38/48 -> 45/56 pairs.

**Why the pin?** `run_bench.py` passed no `--effort`, so runs inherited the ambient `effortLevel` and nothing recorded it. It matters: the same Opus 5 scenarios score 85.0% at `low` and 90.2% at `xhigh`, where output tokens per final word go 2.17 -> 7.58 (reported output tokens include reasoning tokens, so the `xhigh` row would also have broken the "output tokens went DOWN" claim). So: `DEFAULT_EFFORT = "low"`, `--effort` to override, `effort` and `thinking_tokens` recorded per raw file, and `--results-dir` because raw filenames do not encode effort.

**Why `low`?** It is where the existing rows appear to sit: probes at all five levels match their output-token profile at `low` (8.6% mean absolute error), `thinking_tokens` is 0 only there, and `claude-opus-4-6` re-run at `low` reproduces its committed row (2.24 -> 0.40 archived, 2.54 -> 0.33 measured).

**One aside.** `claude-opus-4-8` looks like a bad sample rather than a model property: best baseline in the table (1.05) *and* worst skill score (0.62), which is what makes its 41% the outlier. At pinned `low` it gives 2.04 -> 0.17.
