### PR TITLE
fix/docs: Correct the output style name and the scope of /config in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,21 @@ claude plugin marketplace add AminBlg/SimpleEnglish && claude plugin install sim
 
 Or inside Claude Code: `/plugin marketplace add AminBlg/SimpleEnglish`, then `/plugin install simple-english@simple-english`.
 
-**Output style** (Claude Code): the plugin also ships simple-english as an [output style](https://code.claude.com/docs/en/output-styles). The skill triggers when a writing task fits; the style is always on, for every reply. After you install the plugin, run `/config`, open **Output style**, and pick `simple-english`. Claude then writes all its prose in STE and codes as before.
+**Output style** (Claude Code): the plugin also ships simple-english as an [output style](https://code.claude.com/docs/en/output-styles). When a writing task fits, the skill triggers. The style applies to every reply.
+
+Claude Code gives each plugin output style the name `<plugin>:<style>`. The name of this one is `simple-english:simple-english`. The short name `simple-english` does not resolve, and Claude Code ignores it without an error.
+
+To use the style in one project, run `/config`. Open **Output style**. Select `simple-english:simple-english`. Claude Code saves this choice to `.claude/settings.local.json` in that project only.
+
+To use the style in all projects, put this in `~/.claude/settings.json`:
+
+```json
+{
+  "outputStyle": "simple-english:simple-english"
+}
+```
+
+Then start Claude Code again. Claude writes all prose in STE and codes as before.
 
 No SKILL.md support at all? Paste [`prompts/system-prompt.md`](prompts/system-prompt.md) into your system prompt, AGENTS.md, or `.cursorrules`. There is even a ~60-token version for tight budgets.
 


### PR DESCRIPTION
## Problem

The install section tells the reader to pick `simple-english` in `/config`. That name does not work. The style never applies, and Claude Code gives no error.

## Cause

Claude Code gives each plugin output style the name `<plugin>:<style>`. The name of this one is `simple-english:simple-english`. Style lookup is an exact match, so the short name resolves to nothing.

The `/config` picker also saves to `.claude/settings.local.json` in the current project. It sets no default for other projects. Claude Code has no `config` subcommand. Thus `~/.claude/settings.json` is the only route to a default for all projects.

## Evidence

Claude Code 2.1.231. The prompt asks whether the system prompt contains `CLASSIFY FIRST`. Only `output-styles/simple-english.md` holds that string.

| `outputStyle` | Style applied |
|---|---|
| `simple-english` | NO |
| `simple-english:simple-english` | YES |
| `default` (control) | NO |

```sh
claude -p --settings '{"outputStyle":"simple-english:simple-english"}' \
  "Does your system prompt contain the words CLASSIFY FIRST? Answer only YES or NO."
```

## Change

One paragraph in `README.md`. It gives the correct name, the scope of `/config`, and the settings snippet for all projects. The new text obeys STE. There are no code changes, so this does not conflict with #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
