### PR TITLE
Add claude-fable-5-1 and claude-fable-5 rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/STE_violations-%E2%88%9274.6%25_measured-brightgreen?style=flat" alt="74.6% fewer violations, measured"></a>
-  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/benchmarked_on-7_Claude_models-blueviolet?style=flat" alt="7 models benchmarked"></a>
+  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/STE_violations-%E2%88%9276.1%25_measured-brightgreen?style=flat" alt="76.1% fewer violations, measured"></a>
+  <a href="evals/results/RESULTS.md"><img src="https://img.shields.io/badge/benchmarked_on-9_Claude_models-blueviolet?style=flat" alt="9 models benchmarked"></a>
   <a href="https://agentskills.io"><img src="https://img.shields.io/badge/SKILL.md-open_standard-blue?style=flat" alt="Agent Skills"></a>
   <a href="skills/simple-english/SKILL.md"><img src="https://img.shields.io/badge/version-2.0.0-blue?style=flat" alt="version 2.0.0"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat" alt="MIT"></a>
@@ -83,10 +83,12 @@ More rewrites in [`examples/before-after.md`](examples/before-after.md): READMEs
 
 ## Benchmarks
 
-**74.6% fewer STE violations per 100 words with the skill on, averaged across 7 Claude models × 8 writing tasks (112 generations).** Measured on skill 1.3.0. The 2.0.0 pivot (Plain by default) was checked against 1.3.0 on two models, the reply set, and a blind judge: documents at parity, replies with 43% fewer violations. Details: [`evals/results/pivot-2026-09-01/RESULTS.md`](evals/results/pivot-2026-09-01/RESULTS.md). Deterministic regex linter, same rules for both conditions, reasoning effort pinned to `low`. Method, caveats, and raw files: [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` and a logged-in Claude Code CLI.
+**76.1% fewer STE violations per 100 words with the skill on, averaged across 9 Claude models × 8 writing tasks (144 generations).** Each row uses the skill version from the day we measured it. That is 1.0.0 for the six oldest rows, 1.2.0 for claude-opus-5, and 2.0.0 for both Fable rows. The 2.0.0 pivot (Plain by default) was checked against 1.3.0 on two models, the reply set, and a blind judge: documents at parity, replies with 43% fewer violations. Details: [`evals/results/pivot-2026-09-01/RESULTS.md`](evals/results/pivot-2026-09-01/RESULTS.md). Deterministic regex linter, same rules for both conditions, reasoning effort pinned to `low`. Method, caveats, and raw files: [`evals/results/RESULTS.md`](evals/results/RESULTS.md). Reproduce with `python3 evals/run_bench.py` and a logged-in Claude Code CLI.
 
 | Model | Baseline viol/100w | Skill viol/100w | Reduction |
 |---|---|---|---|
+| claude-fable-5-1 | 1.77 | 0.33 | 81% |
+| claude-fable-5 | 2.73 | 0.51 | 81% |
 | claude-opus-5 | 2.13 | 0.32 | 85% |
 | claude-opus-4-8 | 1.05 | 0.62 | 41% |
 | claude-opus-4-7 | 2.28 | 0.42 | 82% |
@@ -95,7 +97,7 @@ More rewrites in [`examples/before-after.md`](examples/before-after.md): READMEs
 | claude-sonnet-5 | 2.67 | 0.53 | 80% |
 | claude-sonnet-4-6 | 2.06 | 0.52 | 75% |
 
-A blind pairwise judge (claude-opus-4-8, both text orders, no labels) preferred the skill output in 45 of 56 pairs, with 5 ties and 6 losses. Output tokens went down on all seven models.
+A blind pairwise judge (claude-opus-4-8, both text orders, no labels) preferred the skill output in 61 of 72 pairs, with 5 ties and 6 losses. Output tokens went down on all nine models.
 
 **Other harnesses**, same 8 tasks, same linter, one run per cell:
 

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -1,9 +1,11 @@
 # Benchmark results
 
-**74.6% fewer STE violations per 100 words with the skill, averaged across 7 models x 8 tasks (112 generations, measured).**
+**76.1% fewer STE violations per 100 words with the skill, averaged across 9 models x 8 tasks (144 generations, measured).**
 
 | Model | Baseline viol/100w | Skill viol/100w | Reduction | Baseline sent. len | Skill sent. len | Output tok (base->skill) |
 |---|---|---|---|---|---|---|
+| claude-fable-5-1 | 1.77 | 0.33 | 81.4% | 12.9 | 9.8 | 348 -> 236 |
+| claude-fable-5 | 2.73 | 0.51 | 81.3% | 15.1 | 9.6 | 285 -> 250 |
 | claude-opus-5 | 2.13 | 0.32 | 85.0% | 14.1 | 10.8 | 272 -> 241 |
 | claude-opus-4-8 | 1.05 | 0.62 | 41.0% | 10.7 | 10.0 | 260 -> 235 |
 | claude-opus-4-7 | 2.28 | 0.42 | 81.6% | 13.0 | 10.8 | 243 -> 226 |
@@ -18,11 +20,13 @@ For each model x scenario pair, claude-opus-4-8 scored the baseline text and
 the skill text on a 0-10 rubric, twice with the texts in both orders. The
 two scores were averaged to cancel position bias. The judge saw no labels.
 
-Result: the skill output scored higher in 45 of 56 pairs, tied in
-5, and lost in 6. Mean rubric score: 8.12 with the skill, 6.04 without.
+Result: the skill output scored higher in 61 of 72 pairs, tied in
+5, and lost in 6. Mean rubric score: 8.29 with the skill, 6.15 without.
 
 | Model | Skill wins | Ties | Losses |
 |---|---|---|---|
+| claude-fable-5-1 | 8 | 0 | 0 |
+| claude-fable-5 | 8 | 0 | 0 |
 | claude-opus-5 | 7 | 1 | 0 |
 | claude-opus-4-8 | 5 | 1 | 2 |
 | claude-opus-4-7 | 7 | 1 | 0 |
@@ -34,7 +38,7 @@ Result: the skill output scored higher in 45 of 56 pairs, tied in
 Caveats: one judge model, judged once per order. The judge is a Claude
 model and the texts are Claude output, so family bias is possible. Pairs
 judged before effort pinning inherited the ambient setting, so the judge
-pass is not uniform: 8 of 56 judge files record a
+pass is not uniform: 24 of 72 judge files record a
 `judge_effort` and the rest pre-date the pin. Raw judge files:
 results/raw/*__judge__*.json. Reproduce with
 `python3 evals/run_bench.py --judge`.
@@ -53,8 +57,8 @@ results/raw/*__judge__*.json. Reproduce with
   the table assumes they are also `low`, which matches their measured
   output-token profile, but treat that as inferred. Effort moves the numbers a lot:
   claude-opus-5 measured 85.0% at `low` and 90.2% at `xhigh` on the same scenarios.
-- Output tokens include reasoning tokens. Highest `thinking_tokens` recorded in
-  raw/ is 0, so that column is final text.
+- Output tokens include reasoning tokens. The highest `thinking_tokens` in
+  raw/ is 298. On the models that reason, the column is more than final text.
 - One generation per cell. Re-run the matrix for variance; the runner is
   resumable, delete results/raw to start fresh.
 - No tool can guarantee ASD-STE100 compliance, including this one.

--- a/evals/results/raw/claude-fable-5-1__baseline__architecture.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__architecture.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe moves data from Postgres to S3 as Parquet through three decoupled stages connected by bounded queues.\n\nThe reader process opens a server-side cursor and streams rows in fixed-size batches, so memory stays flat regardless of table size. Each batch carries its column metadata and a sequence number.\n\nThe converter consumes batches, coerces Postgres types to Arrow types, and buffers rows until a row group reaches the configured size. It then encodes the group as Parquet and hands the compressed bytes downstream.\n\nThe uploader starts a multipart upload per output object, sends each completed row group as a part, and retries failed parts with exponential backoff. It completes the upload only after every part is acknowledged, and aborts it on unrecoverable failure so no partial objects remain.\n\nBackpressure flows upstream: a slow uploader fills the queue and pauses the reader.",
+  "input_tokens": 2,
+  "output_tokens": 285,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 9340,
+  "cost_usd": 0.17090450000000001,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 140,
+    "sentences": 9,
+    "mean_sentence_words": 15.6,
+    "longest_sentence_words": 24,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__error-message.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__error-message.json
@@ -1,0 +1,35 @@
+{
+  "text": "I can't give you the verbatim text. No copy of the sqlpipe source is available in this environment, and I don't have file search or shell tools loaded here to check, so anything I wrote as \"exact\" would be a guess presented as fact.\n\nWhat I can say with confidence is the shape of it. sqlpipe wraps the AWS SDK error, so the output is sqlpipe's own prefix followed by the SDK's AccessDenied text, roughly:\n\n```\nerror uploading to s3: operation error S3: PutObject, https response error StatusCode: 403, RequestID: <id>, HostID: <id>, api error AccessDenied: Access Denied\n```\n\nThe second half (from \"operation error\" onward) is stable AWS SDK for Go v2 wording. The prefix is sqlpipe's and is the part I can't confirm.\n\nTo get the real string, grep the sqlpipe repo for the S3 upload call:\n\n```\ngrep -rn \"PutObject\\|Upload(\" --include=*.go .\n```\n\nThe `fmt.Errorf` or log call surrounding that hit is the message you want. If you point me at a checkout of the repo, I'll pull the exact lines.",
+  "input_tokens": 115,
+  "output_tokens": 861,
+  "thinking_tokens": 298,
+  "effort": "low",
+  "duration_ms": 25542,
+  "cost_usd": 0.23950724999999998,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 143,
+    "sentences": 9,
+    "mean_sentence_words": 15.9,
+    "longest_sentence_words": 37,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 4,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 7,
+    "violations_per_100w": 4.9
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__getting-started.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__getting-started.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Getting started\n\n**1. Install**\n\nRun the installer script, which downloads the latest sqlpipe binary and places it on your `PATH`:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nVerify the installation with `sqlpipe --version`.\n\n**2. Configure**\n\nsqlpipe reads its settings from a `sqlpipe.yaml` file. Create one in your project directory and define at least a source, a destination, and the tables or queries to move between them. A minimal example:\n\n```yaml\nsource:\n  driver: postgres\n  dsn: postgres://user:pass@localhost:5432/app\ndestination:\n  driver: mysql\n  dsn: mysql://user:pass@localhost:3306/warehouse\npipelines:\n  - name: users\n    query: SELECT * FROM users\n    target_table: users\n```\n\nKeep credentials out of version control; environment variable references are supported.\n\n**3. First run**\n\nExecute the pipelines defined in your config:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe connects to both databases, runs each pipeline in order, and prints a summary of rows transferred. Fix any connection errors reported, then re-run.",
+  "input_tokens": 2,
+  "output_tokens": 402,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 9255,
+  "cost_usd": 0.025868,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 106,
+    "sentences": 9,
+    "mean_sentence_words": 11.4,
+    "longest_sentence_words": 23,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 1,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.83
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__incident-report.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__incident-report.json
@@ -1,0 +1,35 @@
+{
+  "text": "**Resolved: Elevated API error rates**\n\nBetween 14:02 and 14:31 UTC, approximately 12% of API requests failed with HTTP 502 errors. Customers may have seen intermittent failures or timeouts when calling the API during this window.\n\nThe issue was caused by a deploy that unintentionally removed the cache warmup step. New instances began serving traffic before their caches were populated, which overloaded backend services and resulted in 502 responses.\n\nWe identified the cause and reverted the deploy at 14:27 UTC. Error rates returned to normal by 14:31 UTC.\n\nTo prevent recurrence, we are adding a deploy check that requires cache warmup before instances receive traffic. We apologize for the disruption.",
+  "input_tokens": 2,
+  "output_tokens": 239,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7308,
+  "cost_usd": 0.16872749999999997,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 109,
+    "sentences": 8,
+    "mean_sentence_words": 13.5,
+    "longest_sentence_words": 19,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 1,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.75
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__readme-intro.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__readme-intro.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe is a command-line tool that syncs PostgreSQL tables to Amazon S3 as Parquet files. Point it at a database and a bucket, name the tables you want, and it streams each one into columnar Parquet objects ready for Athena, Spark, DuckDB, or any other engine that reads from S3. Schemas are inferred from Postgres column types, so there is no mapping file to maintain.\n\nIt is built for recurring exports rather than one-off dumps. Incremental syncs use a cursor column to copy only new or changed rows, full refreshes rewrite a table in place, and output is partitioned by date or by a column of your choice. sqlpipe runs as a single static binary with no daemon, which makes it a natural fit for cron jobs, CI pipelines, and scheduled containers.",
+  "input_tokens": 2,
+  "output_tokens": 263,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 9557,
+  "cost_usd": 0.018882499999999997,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 132,
+    "sentences": 6,
+    "mean_sentence_words": 22.0,
+    "longest_sentence_words": 35,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.52
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__release-notes.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__release-notes.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe v2.0\n\nThis release includes one breaking API change, a new sync mode, and a significant performance improvement for Parquet output.\n\nBreaking change: the `name` field on `/v2/users` has been split into `first_name` and `last_name`. Clients that read or write `name` must be updated before upgrading. Requests that still send `name` will be rejected with a 400 error.\n\nNew: the `--incremental` flag syncs only rows changed since the previous run instead of reloading the full table. This cuts transfer time and load on the source database for large, frequently updated tables.\n\nPerformance: Parquet writes are now about 40% faster thanks to a reworked buffering and compression pipeline. No configuration changes are needed to benefit.\n\nSee the migration guide for upgrade steps.",
+  "input_tokens": 2,
+  "output_tokens": 251,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7832,
+  "cost_usd": 0.1692745,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 122,
+    "sentences": 10,
+    "mean_sentence_words": 12.0,
+    "longest_sentence_words": 21,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.82
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__runbook-terse.json
@@ -1,0 +1,35 @@
+{
+  "text": "Verify backup exists before migrating.",
+  "input_tokens": 2,
+  "output_tokens": 14,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 4150,
+  "cost_usd": 0.1566535,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 5,
+    "sentences": 1,
+    "mean_sentence_words": 5.0,
+    "longest_sentence_words": 5,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__baseline__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5-1__baseline__troubleshooting.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nIf `sqlpipe` hangs or fails with `connection timed out`, first confirm the host is reachable:\n\n```\npg_isready -h <host> -p 5432\n```\n\nCommon causes:\n\n- **Firewall or security group** blocks port 5432 from the machine running `sqlpipe`. Check inbound rules for your source IP.\n- **Wrong host or port** in the connection string. Verify with `--source` echoed via `sqlpipe config show`.\n- **SSL mismatch**: the server requires TLS but `sslmode=disable` is set. Try `sslmode=require`.\n- **Slow queries**: increase `--connect-timeout` (default 10s) or `--statement-timeout` for large exports.\n\n### S3 permission errors\n\nAn `AccessDenied` or `403 Forbidden` error means the credentials lack rights on the bucket.\n\n- Confirm which identity is active: `aws sts get-caller-identity`.\n- The IAM policy must allow `s3:PutObject`, `s3:GetObject`, and `s3:ListBucket` on the target bucket and prefix.\n- Check for a bucket policy or SCP that overrides the IAM grant.\n- If using `--kms-key`, the role also needs `kms:GenerateDataKey` and `kms:Decrypt`.\n- Verify the `--region` flag matches the bucket's region.",
+  "input_tokens": 2,
+  "output_tokens": 468,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 11200,
+  "cost_usd": 0.029134,
+  "model": "claude-fable-5-1",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 153,
+    "sentences": 18,
+    "mean_sentence_words": 8.0,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 2
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.31
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__architecture.json
+++ b/evals/results/raw/claude-fable-5-1__judge__architecture.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "architecture",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 9,
+    "b_score": 8
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__error-message.json
+++ b/evals/results/raw/claude-fable-5-1__judge__error-message.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "error-message",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 3
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__getting-started.json
+++ b/evals/results/raw/claude-fable-5-1__judge__getting-started.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "getting-started",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__incident-report.json
+++ b/evals/results/raw/claude-fable-5-1__judge__incident-report.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "incident-report",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 7
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__readme-intro.json
+++ b/evals/results/raw/claude-fable-5-1__judge__readme-intro.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "readme-intro",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__release-notes.json
+++ b/evals/results/raw/claude-fable-5-1__judge__release-notes.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "release-notes",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 9,
+    "b_score": 7
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5-1__judge__runbook-terse.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "runbook-terse",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 10
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 8
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__judge__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5-1__judge__troubleshooting.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5-1",
+  "scenario": "troubleshooting",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 6
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__architecture.json
+++ b/evals/results/raw/claude-fable-5-1__skill__architecture.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe copies rows from a Postgres database to Parquet files in S3. Three processes do this work in sequence.\n\nThe reader process connects to Postgres and streams rows in batches. A batch is a fixed group of rows that the reader sends together. The reader holds only the current batch in memory. As a result, the process can copy a large table with a small memory footprint.\n\nThe converter takes each batch and turns it into a Parquet row group. Parquet is a column-based file format for analytics. A row group is a block of rows stored together in one Parquet file. The converter writes the row groups to a file in sequence.\n\nThe uploader writes the Parquet file to S3 as a multipart object. A multipart upload sends the file in parts and joins the parts at the end. If a part fails, the uploader sends that part again. This retry logic protects the upload from short network errors.",
+  "input_tokens": 2,
+  "output_tokens": 271,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7770,
+  "cost_usd": 0.3267715,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 160,
+    "sentences": 14,
+    "mean_sentence_words": 11.4,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__error-message.json
+++ b/evals/results/raw/claude-fable-5-1__skill__error-message.json
@@ -1,0 +1,35 @@
+{
+  "text": "```\nError: sqlpipe cannot upload to S3. The upload failed with the S3 error \"AccessDenied\".\nThe IAM credentials do not have the s3:PutObject permission for this bucket.\nAdd the s3:PutObject permission to the IAM policy of the credentials that sqlpipe uses. Then run the command again.\n```",
+  "input_tokens": 2,
+  "output_tokens": 112,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 5698,
+  "cost_usd": 0.3185495,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 1,
+    "sentences": 0,
+    "mean_sentence_words": 0.0,
+    "longest_sentence_words": 0,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__getting-started.json
+++ b/evals/results/raw/claude-fable-5-1__skill__getting-started.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Getting started\n\nsqlpipe is a command-line tool that moves data between SQL databases. This section shows how to install it, configure it, and run it for the first time.\n\n### Install sqlpipe\n\n1. Open a terminal.\n2. Run this command:\n\n```\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\n3. Make sure that the installation succeeded. Run `sqlpipe --version`.\n\n### Write the configuration\n\nsqlpipe reads its configuration from a YAML file. YAML is a text format for structured data.\n\n1. Create a file with the name `sqlpipe.yaml` in your working directory.\n2. Add the connection details for the source database.\n3. Add the connection details for the target database.\n4. Save the file.\n\n### Run sqlpipe for the first time\n\n1. Run this command in the directory that contains the configuration:\n\n```\nsqlpipe run --config sqlpipe.yaml\n```\n\n2. Read the output. sqlpipe reports each table that it copies.\n3. If the run fails, read the error message and correct the configuration. Then run the command again.",
+  "input_tokens": 2,
+  "output_tokens": 349,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 8825,
+  "cost_usd": 0.3311885,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 135,
+    "sentences": 17,
+    "mean_sentence_words": 7.4,
+    "longest_sentence_words": 16,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__incident-report.json
+++ b/evals/results/raw/claude-fable-5-1__skill__incident-report.json
@@ -1,0 +1,35 @@
+{
+  "text": "**API errors: 502 responses (resolved)**\n\nBetween 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502 errors. All other requests completed as normal. The incident is resolved.\n\n**Cause**\n\nAt 14:02 UTC, we deployed a change to the API. This change removed the step that warms the cache (loads data into the cache before traffic arrives). As a result, the API servers started with an empty cache. Some requests timed out, and the servers returned HTTP 502 errors.\n\n**Recovery**\n\nAt 14:27 UTC, we reverted the deploy. By 14:31 UTC, the error rate returned to normal.\n\n**Next steps**\n\nWe will add a test that makes sure that the cache warmup step runs on every deploy. We apologize for the disruption.",
+  "input_tokens": 2,
+  "output_tokens": 260,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 6992,
+  "cost_usd": 0.3263545,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 120,
+    "sentences": 12,
+    "mean_sentence_words": 10.0,
+    "longest_sentence_words": 19,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__readme-intro.json
+++ b/evals/results/raw/claude-fable-5-1__skill__readme-intro.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe is a command-line tool that copies Postgres tables to Amazon S3 as Parquet files. Parquet is a compressed file format made for columns of data. Analytics tools such as Athena, Spark, and DuckDB read it directly. You run sqlpipe on a schedule, and it keeps the files in S3 in step with your database.\n\nsqlpipe reads each table in pages, so a large table does not fill the memory of the host. Each run writes new Parquet files and then updates a manifest, a small index file that lists the current files. As a result, a reader never sees a partial run. You describe the source database, the tables, and the target bucket in one configuration file. Then you start a run with one command.",
+  "input_tokens": 2,
+  "output_tokens": 225,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7927,
+  "cost_usd": 0.3242075,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 126,
+    "sentences": 9,
+    "mean_sentence_words": 14.0,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__release-notes.json
+++ b/evals/results/raw/claude-fable-5-1__skill__release-notes.json
@@ -1,0 +1,35 @@
+{
+  "text": "# sqlpipe v2.0\n\n## Breaking change: user names are split\n\nThe `name` field of `/v2/users` is removed. The endpoint now returns two fields: `first_name` and `last_name`.\n\nBefore you upgrade, update every client that reads the `name` field. After the upgrade, a request that reads `name` gets an empty value.\n\n## New flag: incremental sync\n\nThe `--incremental` flag copies only the rows that changed since the last run. An incremental sync (a sync that skips unchanged rows) is faster than a full sync on large tables.\n\nTo use it, add the flag to your usual command:\n\n```\nsqlpipe run --config sqlpipe.yaml --incremental\n```\n\n## Faster Parquet writes\n\nParquet writes are 40% faster than in v1.x. Parquet is a compressed file format for tables. You do not have to change your configuration to get this speed.",
+  "input_tokens": 2,
+  "output_tokens": 283,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 11654,
+  "cost_usd": 0.32744650000000003,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 109,
+    "sentences": 11,
+    "mean_sentence_words": 9.9,
+    "longest_sentence_words": 18,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5-1__skill__runbook-terse.json
@@ -1,0 +1,35 @@
+{
+  "text": "Before you run the migration, make sure that the backup exists.",
+  "input_tokens": 2,
+  "output_tokens": 20,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 5067,
+  "cost_usd": 0.3135105,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5-1__skill__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5-1__skill__troubleshooting.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Troubleshooting\n\n### Connection timeouts to Postgres\n\nsqlpipe stops with `dial tcp: i/o timeout` when it cannot connect to the Postgres port (5432 by default).\n\n1. Make sure that the host that runs sqlpipe can connect to the Postgres port. A firewall or security group usually blocks the connection.\n2. If the database is managed (RDS, Cloud SQL), make sure that the instance accepts connections from the IP address of sqlpipe.\n3. If the network is slow, increase the timeout value in the configuration.\n\n### S3 permission errors\n\nsqlpipe stops with `AccessDenied` when the AWS credentials do not have the permissions that it needs.\n\n1. Make sure that the credentials in the configuration are the credentials that you intend to use.\n2. Make sure that the IAM policy (the AWS rule set that gives permissions) allows the `s3:PutObject` and `s3:ListBucket` actions on the bucket.\n3. If the bucket has a bucket policy, make sure that the bucket policy does not deny the same actions.\n4. Run sqlpipe again.",
+  "input_tokens": 2,
+  "output_tokens": 369,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 8412,
+  "cost_usd": 0.33120649999999996,
+  "model": "claude-fable-5-1",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 154,
+    "sentences": 10,
+    "mean_sentence_words": 14.7,
+    "longest_sentence_words": 22,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 4,
+    "violations_per_100w": 2.6
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__architecture.json
+++ b/evals/results/raw/claude-fable-5__baseline__architecture.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe moves data from Postgres to S3 through three decoupled stages connected by bounded channels.\n\nThe reader opens a server-side cursor against Postgres and streams rows in fixed-size batches, keeping memory flat regardless of table size. Each batch is handed to the converter, which accumulates rows into columnar buffers and emits a Parquet row group once a size threshold is reached, handling type mapping and compression. Completed row groups flow to the uploader, which assembles them into Parquet files and writes each file to S3 as a multipart upload, retrying failed parts with exponential backoff and aborting incomplete uploads on unrecoverable errors.\n\nBackpressure propagates naturally: a slow upload fills the channels and pauses the reader, so throughput is governed by the slowest stage rather than unbounded buffering.",
+  "input_tokens": 2,
+  "output_tokens": 272,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7302,
+  "cost_usd": 0.178035,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 127,
+    "sentences": 6,
+    "mean_sentence_words": 21.2,
+    "longest_sentence_words": 36,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 1.57
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__error-message.json
+++ b/evals/results/raw/claude-fable-5__baseline__error-message.json
@@ -1,0 +1,35 @@
+{
+  "text": "I can't give you that verbatim, and I'd rather not fabricate it: I don't have sqlpipe's source memorized well enough to reproduce its exact error string, and inventing \"exact\" message text would be worse than useless if you're writing log-matching rules or docs against it.\n\nWhat I can tell you reliably is that sqlpipe wraps the AWS SDK for Go error, so the S3 failure surfaces the SDK's standard form, something like:\n\n```\nerror uploading file to s3 :: operation error S3: PutObject, https response error StatusCode: 403, RequestID: <id>, HostID: <id>, api error AccessDenied: Access Denied\n```\n\nThe `operation error S3: PutObject ... api error AccessDenied: Access Denied` portion is the stable AWS SDK v2 part; the prefix wording is sqlpipe's and I'm not certain of it. If you need the exact text, the quickest check is the sqlpipe repo (grep for `PutObject` or `upload` in its S3/transfer code), or just trigger the failure once with scoped-down credentials. I'm happy to pull the repo and find the exact string if you want.",
+  "input_tokens": 2,
+  "output_tokens": 562,
+  "thinking_tokens": 188,
+  "effort": "low",
+  "duration_ms": 12326,
+  "cost_usd": 0.192263,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 138,
+    "sentences": 6,
+    "mean_sentence_words": 23.0,
+    "longest_sentence_words": 33,
+    "violations": {
+      "sentence_over_limit": 4,
+      "contraction": 4,
+      "banned_modal": 1,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 1,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 12,
+    "violations_per_100w": 8.7
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__getting-started.json
+++ b/evals/results/raw/claude-fable-5__baseline__getting-started.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Getting started\n\nInstall sqlpipe with a single command:\n\n```sh\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThis downloads the latest release and places the `sqlpipe` binary on your `PATH`. Verify the installation with `sqlpipe --version`.\n\nNext, create a `sqlpipe.yaml` file in your project directory. This is where you define your source and target connections and the pipelines between them. A minimal example:\n\n```yaml\nsource:\n  type: postgres\n  dsn: postgres://user:pass@localhost:5432/mydb\ntarget:\n  type: mysql\n  dsn: user:pass@tcp(localhost:3306)/mydb\n```\n\nAdjust the connection details to match your databases. Keep credentials out of version control: reference environment variables where possible.\n\nFinally, start your first run:\n\n```sh\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe connects to both databases, validates the configuration, and begins transferring data. Progress and any errors are logged to stdout.",
+  "input_tokens": 2,
+  "output_tokens": 343,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7312,
+  "cost_usd": 0.182102,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 97,
+    "sentences": 12,
+    "mean_sentence_words": 8.1,
+    "longest_sentence_words": 15,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 1,
+    "violations_per_100w": 1.03
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__incident-report.json
+++ b/evals/results/raw/claude-fable-5__baseline__incident-report.json
@@ -1,0 +1,35 @@
+{
+  "text": "**API Incident Report \u2013 Elevated 502 Errors**\n\nBetween 14:02 and 14:31 UTC, approximately 12% of API requests failed with HTTP 502 errors. We apologize for the disruption.\n\nThe incident was triggered by a deploy at 14:02 that inadvertently removed the cache warmup step, causing backend instances to come online unprepared for production traffic and return errors under load.\n\nWe identified the cause and reverted the deploy at 14:27. Error rates returned to normal by 14:31, and the incident was resolved.\n\nTo prevent recurrence, we are adding automated checks to ensure cache warmup runs on every deploy.",
+  "input_tokens": 2,
+  "output_tokens": 212,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7183,
+  "cost_usd": 0.175143,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 96,
+    "sentences": 6,
+    "mean_sentence_words": 16.0,
+    "longest_sentence_words": 31,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 1,
+      "semicolon": 0,
+      "em_dash": 1,
+      "latin_abbrev": 0,
+      "slop_word": 1,
+      "trailing_condition": 0,
+      "synonym_rotation": 1
+    },
+    "violations_total": 5,
+    "violations_per_100w": 5.21
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__readme-intro.json
+++ b/evals/results/raw/claude-fable-5__baseline__readme-intro.json
@@ -1,0 +1,35 @@
+{
+  "text": "**sqlpipe** syncs PostgreSQL tables to Amazon S3 as Parquet files with a single command. Point it at a database, list the tables you want, and it handles the rest: streaming rows out of Postgres, converting them to columnar Parquet with schema types preserved, and writing partitioned files to your bucket. It supports full and incremental syncs, so you can run it on a schedule and only ship rows that changed since the last run.\n\nBuilt for data teams who need Postgres data in their lake without standing up a full ETL platform, sqlpipe is a single static binary with no runtime dependencies. Configure it with a YAML file or flags, drop it into cron or CI, and your warehouse queries stay fresh.",
+  "input_tokens": 2,
+  "output_tokens": 234,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7507,
+  "cost_usd": 0.377147,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 122,
+    "sentences": 6,
+    "mean_sentence_words": 20.3,
+    "longest_sentence_words": 28,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.82
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__release-notes.json
+++ b/evals/results/raw/claude-fable-5__baseline__release-notes.json
@@ -1,0 +1,35 @@
+{
+  "text": "# sqlpipe v2.0\n\n## Breaking change\n\nThe `name` field on `/v2/users` has been split into `first_name` and `last_name`. Responses no longer include `name`, and requests that send it will be rejected. Update any clients that read or write user names to use the new fields before upgrading.\n\n## New: incremental syncs\n\nA new `--incremental` flag syncs only rows changed since the last run instead of copying full tables. This can dramatically cut transfer times and load on source databases for large, frequently synced datasets.\n\n## Performance\n\nParquet writes are now about 40% faster thanks to internal optimizations in the write path. No configuration changes are needed: existing pipelines that output Parquet benefit automatically.",
+  "input_tokens": 2,
+  "output_tokens": 232,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 7711,
+  "cost_usd": 0.17610499999999998,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 103,
+    "sentences": 8,
+    "mean_sentence_words": 12.9,
+    "longest_sentence_words": 17,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 1,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 1,
+    "violations_per_100w": 0.97
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5__baseline__runbook-terse.json
@@ -1,0 +1,35 @@
+{
+  "text": "Verify backup exists before migrating.",
+  "input_tokens": 2,
+  "output_tokens": 14,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 6167,
+  "cost_usd": 0.164434,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 5,
+    "sentences": 1,
+    "mean_sentence_words": 5.0,
+    "longest_sentence_words": 5,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__baseline__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5__baseline__troubleshooting.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Troubleshooting\n\n### Postgres connection timeouts\n\nIf sqlpipe hangs or fails with `connection timed out` when reaching Postgres, first verify the host and port are reachable: `pg_isready -h <host> -p 5432` or `nc -zv <host> 5432`. Common causes are a firewall or security group blocking port 5432, a wrong host in the connection string, or Postgres not listening on external interfaces (`listen_addresses` in `postgresql.conf`) or rejecting the client in `pg_hba.conf`. For slow networks, raise the timeout with `--connect-timeout` or the `connect_timeout` connection string parameter. Check server-side connection limits (`max_connections`) if timeouts appear under load.\n\n### S3 permission errors\n\n`AccessDenied` errors usually mean missing IAM permissions. sqlpipe needs `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket` on the target bucket and prefix. Confirm your credentials are loaded (`aws sts get-caller-identity`), the bucket region matches your configuration, and any bucket policy or KMS key policy also grants access. Expired session tokens produce similar errors: refresh and retry.",
+  "input_tokens": 2,
+  "output_tokens": 409,
+  "thinking_tokens": 0,
+  "effort": "low",
+  "duration_ms": 9319,
+  "cost_usd": 0.184425,
+  "model": "claude-fable-5",
+  "condition": "baseline",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 140,
+    "sentences": 10,
+    "mean_sentence_words": 14.0,
+    "longest_sentence_words": 37,
+    "violations": {
+      "sentence_over_limit": 2,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 1,
+      "synonym_rotation": 2
+    },
+    "violations_total": 5,
+    "violations_per_100w": 3.57
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__architecture.json
+++ b/evals/results/raw/claude-fable-5__judge__architecture.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "architecture",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__error-message.json
+++ b/evals/results/raw/claude-fable-5__judge__error-message.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "error-message",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 3
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__getting-started.json
+++ b/evals/results/raw/claude-fable-5__judge__getting-started.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "getting-started",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 10
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__incident-report.json
+++ b/evals/results/raw/claude-fable-5__judge__incident-report.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "incident-report",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__readme-intro.json
+++ b/evals/results/raw/claude-fable-5__judge__readme-intro.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "readme-intro",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 6,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__release-notes.json
+++ b/evals/results/raw/claude-fable-5__judge__release-notes.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "release-notes",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 9
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5__judge__runbook-terse.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "runbook-terse",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 8,
+    "b_score": 10
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 8
+  }
+}

--- a/evals/results/raw/claude-fable-5__judge__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5__judge__troubleshooting.json
@@ -1,0 +1,13 @@
+{
+  "model": "claude-fable-5",
+  "scenario": "troubleshooting",
+  "judge_effort": "low",
+  "order1_base_first": {
+    "a_score": 4,
+    "b_score": 8
+  },
+  "order2_skill_first": {
+    "a_score": 9,
+    "b_score": 6
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__architecture.json
+++ b/evals/results/raw/claude-fable-5__skill__architecture.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe moves data from Postgres to S3 with three processes: a reader, a converter, and an uploader.\n\nThe reader streams rows from Postgres in batches. A batch is a fixed number of rows held in memory. Streaming keeps memory use low because the reader never loads the full table.\n\nThe converter turns each batch into a Parquet row group. Parquet is a columnar file format (data stored by column, not by row). A row group is one self-contained block of rows inside a Parquet file.\n\nThe uploader writes the Parquet data to S3 as multipart objects. A multipart upload sends a large object in separate parts. If a part fails, the uploader sends that part again. This retry logic makes the pipeline safe on unstable networks.",
+  "input_tokens": 2,
+  "output_tokens": 317,
+  "thinking_tokens": 82,
+  "effort": "low",
+  "duration_ms": 9215,
+  "cost_usd": 0.33685699999999996,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "architecture",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 126,
+    "sentences": 12,
+    "mean_sentence_words": 10.5,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__error-message.json
+++ b/evals/results/raw/claude-fable-5__skill__error-message.json
@@ -1,0 +1,35 @@
+{
+  "text": "```\nsqlpipe could not upload the file to S3. Amazon returned \"AccessDenied\".\nThe IAM credentials do not have the s3:PutObject permission for this bucket.\nAdd the s3:PutObject permission to the IAM policy, then run sqlpipe again.\n```",
+  "input_tokens": 2,
+  "output_tokens": 121,
+  "thinking_tokens": 27,
+  "effort": "low",
+  "duration_ms": 5846,
+  "cost_usd": 0.326765,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "error-message",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 1,
+    "sentences": 0,
+    "mean_sentence_words": 0.0,
+    "longest_sentence_words": 0,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__getting-started.json
+++ b/evals/results/raw/claude-fable-5__skill__getting-started.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Getting started\n\nsqlpipe is a command-line tool that moves data between databases.\n\n### 1. Install sqlpipe\n\nRun this command in your terminal:\n\n```\ncurl -sSL https://get.sqlpipe.dev | sh\n```\n\nThis command downloads sqlpipe and installs it on your machine.\n\n### 2. Create the configuration\n\nsqlpipe reads its configuration from a file named `sqlpipe.yaml`. The configuration names the source database, the target database, and the tables to copy.\n\n1. Create a file named `sqlpipe.yaml` in your working directory.\n2. Add the connection details for the source database and the target database.\n3. Make sure that the credentials in the file are correct.\n\n### 3. Run sqlpipe for the first time\n\nRun this command:\n\n```\nsqlpipe run --config sqlpipe.yaml\n```\n\nsqlpipe connects to the two databases and copies the data. If the run fails, read the error message. The message names the connection or the table that caused the failure.",
+  "input_tokens": 2,
+  "output_tokens": 334,
+  "thinking_tokens": 14,
+  "effort": "low",
+  "duration_ms": 7864,
+  "cost_usd": 0.338219,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "getting-started",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 117,
+    "sentences": 12,
+    "mean_sentence_words": 9.5,
+    "longest_sentence_words": 14,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__incident-report.json
+++ b/evals/results/raw/claude-fable-5__skill__incident-report.json
@@ -1,0 +1,35 @@
+{
+  "text": "**Elevated API errors on September 2**\n\nBetween 14:02 and 14:31 UTC, 12% of API requests failed with HTTP 502 errors. All other requests completed normally.\n\nA deploy at 14:02 removed the cache warmup step. The cache warmup step fills the cache before the service accepts traffic. Without it, the service sent requests to servers that were not ready. These requests failed.\n\nWe reverted the deploy at 14:27. Error rates returned to normal at 14:31. The incident is resolved.\n\nWe will add an automated test that blocks a deploy when the cache warmup step is missing. We apologize for the disruption.",
+  "input_tokens": 2,
+  "output_tokens": 259,
+  "thinking_tokens": 53,
+  "effort": "low",
+  "duration_ms": 7151,
+  "cost_usd": 0.33408499999999997,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "incident-report",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 100,
+    "sentences": 11,
+    "mean_sentence_words": 9.1,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 1,
+      "trailing_condition": 1,
+      "synonym_rotation": 0
+    },
+    "violations_total": 2,
+    "violations_per_100w": 2.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__readme-intro.json
+++ b/evals/results/raw/claude-fable-5__skill__readme-intro.json
@@ -1,0 +1,35 @@
+{
+  "text": "sqlpipe is a command-line tool that copies Postgres tables to Amazon S3. It writes each table as a Parquet file (a compressed, column-based file format). Analytics tools such as Athena, DuckDB, and Spark can read these files directly. You give sqlpipe a connection string, a list of tables, and a target bucket. It does the rest.\n\nYou can run sqlpipe once for a single export, or on a schedule for regular syncs. Each run is idempotent (you can run it again without side effects), so a failed job is safe to retry. sqlpipe ships as one binary with no runtime dependencies. It runs on Linux, macOS, and Windows, and it works well in containers and CI pipelines.",
+  "input_tokens": 2,
+  "output_tokens": 284,
+  "thinking_tokens": 53,
+  "effort": "low",
+  "duration_ms": 7314,
+  "cost_usd": 0.334928,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "readme-intro",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 117,
+    "sentences": 9,
+    "mean_sentence_words": 13.0,
+    "longest_sentence_words": 20,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__release-notes.json
+++ b/evals/results/raw/claude-fable-5__skill__release-notes.json
@@ -1,0 +1,35 @@
+{
+  "text": "# sqlpipe v2.0 release notes\n\n## Breaking change: user name fields\n\nThe `/v2/users` endpoint no longer returns the `name` field. It now returns two fields: `first_name` and `last_name`. If your client reads the `name` field, update it before you upgrade. Requests that send the `name` field will fail.\n\n## New: incremental transfers\n\nThe `--incremental` flag transfers only the rows that changed since the last run. Without the flag, sqlpipe transfers the full table, as before.\n\n## Faster Parquet writes\n\nsqlpipe writes Parquet files (a compressed column-based file format) 40% faster than v1. You do not have to change your configuration to get this speed.",
+  "input_tokens": 2,
+  "output_tokens": 251,
+  "thinking_tokens": 26,
+  "effort": "low",
+  "duration_ms": 8093,
+  "cost_usd": 0.33362700000000006,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "release-notes",
+  "type": "descriptive",
+  "lint": {
+    "type": "descriptive",
+    "words": 86,
+    "sentences": 9,
+    "mean_sentence_words": 9.6,
+    "longest_sentence_words": 13,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__runbook-terse.json
+++ b/evals/results/raw/claude-fable-5__skill__runbook-terse.json
@@ -1,0 +1,35 @@
+{
+  "text": "Before you run the migration, make sure that the backup exists.",
+  "input_tokens": 2,
+  "output_tokens": 66,
+  "thinking_tokens": 46,
+  "effort": "low",
+  "duration_ms": 5158,
+  "cost_usd": 0.323591,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "runbook-terse",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 11,
+    "sentences": 1,
+    "mean_sentence_words": 11.0,
+    "longest_sentence_words": 11,
+    "violations": {
+      "sentence_over_limit": 0,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 0,
+      "synonym_rotation": 0
+    },
+    "violations_total": 0,
+    "violations_per_100w": 0.0
+  }
+}

--- a/evals/results/raw/claude-fable-5__skill__troubleshooting.json
+++ b/evals/results/raw/claude-fable-5__skill__troubleshooting.json
@@ -1,0 +1,35 @@
+{
+  "text": "## Troubleshooting\n\n### Connection timeouts to Postgres\n\nsqlpipe stops with `dial tcp: i/o timeout` when it cannot connect to the Postgres port (5432 by default).\n\n1. Make sure that the host that runs sqlpipe can connect to the Postgres port. A firewall or security group usually blocks the connection.\n2. If the database is managed (RDS, Cloud SQL), make sure that the instance accepts connections from the IP address of sqlpipe.\n3. If the network is slow, increase the timeout value in the configuration.\n\n### S3 permission errors\n\nsqlpipe stops with `AccessDenied` when its credentials do not permit the S3 operation.\n\n1. Make sure that the credentials in the configuration are current and not expired.\n2. Make sure that the IAM policy permits `s3:GetObject` and `s3:PutObject` on the bucket. IAM (Identity and Access Management) controls access to AWS resources.\n3. If the bucket belongs to a different AWS account, make sure that the bucket policy also permits access.",
+  "input_tokens": 2,
+  "output_tokens": 372,
+  "thinking_tokens": 22,
+  "effort": "low",
+  "duration_ms": 8437,
+  "cost_usd": 0.339157,
+  "model": "claude-fable-5",
+  "condition": "skill",
+  "scenario": "troubleshooting",
+  "type": "procedural",
+  "lint": {
+    "type": "procedural",
+    "words": 144,
+    "sentences": 10,
+    "mean_sentence_words": 13.8,
+    "longest_sentence_words": 21,
+    "violations": {
+      "sentence_over_limit": 1,
+      "contraction": 0,
+      "banned_modal": 0,
+      "perfect_tense": 0,
+      "ing_clause": 0,
+      "semicolon": 0,
+      "em_dash": 0,
+      "latin_abbrev": 0,
+      "slop_word": 0,
+      "trailing_condition": 2,
+      "synonym_rotation": 0
+    },
+    "violations_total": 3,
+    "violations_per_100w": 2.08
+  }
+}

--- a/evals/results/results.json
+++ b/evals/results/results.json
@@ -1,6 +1,30 @@
 {
-  "generated": "2026-08-12",
+  "generated": "2026-09-02",
   "models": [
+    {
+      "model": "claude-fable-5-1",
+      "baseline_viol_per_100w": 1.77,
+      "baseline_mean_sentence": 12.9,
+      "baseline_output_tokens": 348,
+      "baseline_n": 8,
+      "skill_viol_per_100w": 0.33,
+      "skill_mean_sentence": 9.8,
+      "skill_output_tokens": 236,
+      "skill_n": 8,
+      "reduction_pct": 81.4
+    },
+    {
+      "model": "claude-fable-5",
+      "baseline_viol_per_100w": 2.73,
+      "baseline_mean_sentence": 15.1,
+      "baseline_output_tokens": 285,
+      "baseline_n": 8,
+      "skill_viol_per_100w": 0.51,
+      "skill_mean_sentence": 9.6,
+      "skill_output_tokens": 250,
+      "skill_n": 8,
+      "reduction_pct": 81.3
+    },
     {
       "model": "claude-opus-5",
       "baseline_viol_per_100w": 2.13,
@@ -86,10 +110,10 @@
       "reduction_pct": 74.8
     }
   ],
-  "runs": 112,
+  "runs": 144,
   "efforts": [
     "low",
     "unrecorded"
   ],
-  "max_thinking_tokens": 0
+  "max_thinking_tokens": 298
 }

--- a/evals/run_bench.py
+++ b/evals/run_bench.py
@@ -32,6 +32,8 @@ SKILL = HERE.parent / "skills" / "simple-english" / "SKILL.md"
 RESULTS = HERE / "results"
 RAW = RESULTS / "raw"
 MODELS = [
+    "claude-fable-5-1",
+    "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -231,8 +233,10 @@ def report(table, meta, effort):
         f"  the table assumes they are also `{DEFAULT_EFFORT}`, which matches their measured",
         "  output-token profile, but treat that as inferred. Effort moves the numbers a lot:",
         "  claude-opus-5 measured 85.0% at `low` and 90.2% at `xhigh` on the same scenarios.",
-        "- Output tokens include reasoning tokens. Highest `thinking_tokens` recorded in",
-        f"  raw/ is {meta['max_thinking_tokens']}, so that column is final text.",
+        "- Output tokens include reasoning tokens. The highest `thinking_tokens` in",
+        f"  raw/ is {meta['max_thinking_tokens']}. "
+        + ("The column is final text." if not meta["max_thinking_tokens"]
+           else "On the models that reason, the column is more than final text."),
         "- One generation per cell. Re-run the matrix for variance; the runner is",
         "  resumable, delete results/raw to start fresh.",
         "- No tool can guarantee ASD-STE100 compliance, including this one.",


### PR DESCRIPTION
Adds two rows to the benchmark table: `claude-fable-5-1` and `claude-fable-5`.

| Model | Baseline viol/100w | Skill viol/100w | Reduction |
|---|---|---|---|
| claude-fable-5-1 | 1.77 | 0.33 | 81% |
| claude-fable-5 | 2.73 | 0.51 | 81% |

The headline moves from 74.6% to 76.1%, across 9 models and 144 generations. The judge preferred the skill in 61 of 72 pairs. Both Fable models won all 8 of their pairs.

Method: skill 2.0.0, effort pinned to `low`, the same 8 scenarios and linter, one generation per cell.

Two fixes that the new data forced:

- Both Fable models spend reasoning tokens at `low` effort, where every other row records zero. The report line that called the output-token column final text is now conditional.
- The README said that the whole table used skill 1.3.0. Git shows 1.0.0 for the six oldest rows and 1.2.0 for `claude-opus-5`. PR #13 added 1.3.0 on 2026-08-20, after both runs. The README now names the version for each row.

One note for anyone who re-runs the benchmark. The simple-english plugin loads the skill at session start, so the skill reaches the baseline condition too. I disabled the plugin for these runs. With the plugin on, the `claude-sonnet-4-6` baseline scores 0.56 violations per 100 words instead of 2.59. That is the same as its skill score, so the benchmark then shows almost no benefit.
