### PR TITLE
fix(lint): strip table rows and make list items sentence boundaries

### DIFF
--- a/evals/ste_lint.py
+++ b/evals/ste_lint.py
@@ -69,11 +69,13 @@ def strip_code(text):
     text = re.sub(r"`[^`\n]+`", " CODESPAN ", text)  # one word per Rule 8.6
     text = re.sub(r"^#+\s.*$", " ", text, flags=re.M)  # headings exempt (titles, 8.6)
     text = re.sub(r"https?://\S+", " URL ", text)
+    text = re.sub(r"^\s*\|.*\|\s*$", " ", text, flags=re.M)  # table rows (cells are not sentences)
     return text
 
 
 def sentences(text):
-    text = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text, flags=re.M)  # list markers
+    # Append ". " to each item so items become their own sentence units instead of merging.
+    text = re.sub(r"^\s*([-*]|\d+\.)\s+(.*?)$", r"\2. ", text, flags=re.M)
     parts = re.split(r"(?<=[.!?:])\s+", text)
     return [p.strip() for p in parts if len(p.strip().split()) >= 2]
 
@@ -134,6 +136,31 @@ CLEAN_FIXTURE = """The system retries a failed upload automatically. This proces
 
 If failures continue, make sure that your credentials are correct. If the problem continues, contact support."""
 
+TABLE_FIXTURE = """\
+| Column A | Column B | Column C |
+|----------|----------|----------|
+| Cell one that is very long and has many words | Cell two that is also quite long | Cell three |
+| More data here in this cell | And more data here too | And even more here |
+"""
+
+LIST_FIXTURE = """\
+The following items are available:
+
+- First item without a period at the end of the line
+- Second item without a period at the end of the line
+- Third item without a period at the end of the line
+
+Following prose sentence.
+"""
+
+LABEL_LIST_FIXTURE = """\
+**Helix owns:**
+
+- Learner authentication and session management
+- Identity verification and multi-factor authentication
+- Privacy controls and consent management
+"""
+
 # Only the first three dashes must be flagged as logic junctions.
 DASH_FIXTURE = """The deploy failed — the disk was full.
 The upload failed -- the token expired.
@@ -165,6 +192,17 @@ def self_test():
     assert clean["violations_total"] == 0, clean
     assert lint("We delve into the landscape.", "descriptive")["violations"]["slop_word"] == 2
     assert dashes["violations"]["em_dash"] == 3, dashes
+    # Table rows and list items must not produce false sentence_over_limit hits.
+    assert lint(TABLE_FIXTURE, "descriptive")["violations"]["sentence_over_limit"] == 0, \
+        "table rows produced false sentence_over_limit"
+    assert lint(LIST_FIXTURE, "descriptive")["violations"]["sentence_over_limit"] == 0, \
+        "bullet list produced false sentence_over_limit"
+    assert lint(LABEL_LIST_FIXTURE, "descriptive")["violations"]["sentence_over_limit"] == 0, \
+        "bold label + list produced false sentence_over_limit"
+    # A genuine long prose sentence must still flag.
+    long_prose = "a " * 30  # 30 repetitions of the same word, one space each
+    assert lint(long_prose, "descriptive")["violations"]["sentence_over_limit"] >= 1, \
+        "genuine long sentence was not flagged"
     print("self-test OK:", slop["violations_total"], "violations in slop fixture, 0 in clean")
 
 


### PR DESCRIPTION
## Problem

Markdown tables and bullet lists produce false `sentence_over_limit` violations.

The linter counts words by splitting text on `[.!?:]` followed by whitespace. Table rows and list items usually have no terminal punctuation, so all rows/items concatenate into one giant "sentence". A pipe character (`|`) in a table is also counted as a word, inflating the count further.

Example — a four-row table fires `sentence_over_limit` with a reported length of 60+ words. A `**Label:**` lead-in above an unpunctuated list merges the label and all items into one token.

## Fix

Two changes in `evals/ste_lint.py`:

**`strip_code()`** — strip table rows so cells are fully exempt from sentence-length counting (same treatment as headings and code fences):

```python
text = re.sub(r"^\s*\|.*\|\s*$", " ", text, flags=re.M)  # table rows (cells are not sentences)
```

**`sentences()`** — append `". "` to each list item instead of just stripping the bullet/number marker. This ensures items without terminal punctuation each end at a sentence boundary and cannot merge with one another or with following prose:

```python
text = re.sub(r"^\s*([-*]|\d+\.)\s+(.*?)$", r"\2. ", text, flags=re.M)
```

## Tests

Three fixtures added to `self_test()`:

| Fixture | Pattern | Expected |
|---------|---------|---------|
| `TABLE_FIXTURE` | Multi-row markdown table | `sentence_over_limit == 0` |
| `LIST_FIXTURE` | Bullet list, no terminal punctuation | `sentence_over_limit == 0` |
| `LABEL_LIST_FIXTURE` | `**Bold:**` lead-in + list | `sentence_over_limit == 0` |

A 30-word prose run-on is also asserted to still flag, to guard against over-broad suppression.

All existing self-tests and hook tests pass without modification.