### PR TITLE
Skip agent-internal Markdown in the file check

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -51,3 +51,21 @@ Two more hooks run under Claude Code, both advisory. Neither one blocks.
 - `Stop`: the same script reads the last reply and adds a system message when the reply breaks the register: more than five sentences outside code and lists, a filler opener or closer, or a slop word.
 
 Codex runs only the `SessionStart` hook. Test the checks with `python3 src/hooks/test_lint_hook.py`.
+
+## What the file check skips
+
+The writing rules cover the documents that you write for a reader. They do not cover the files that the agent keeps for itself, such as memory files. A summary of the violations in such a file only spends tokens. The `PostToolUse` check therefore skips three groups of paths:
+
+- Every path under the Claude configuration directory. The check reads `CLAUDE_CONFIG_DIR` and falls back to `~/.claude`.
+- Every path with a `.claude` directory component, for example `my-project/.claude/agent-memory/reviewer/MEMORY.md`. A skill or a command that you write under `.claude/` is also skipped.
+- Every path that matches a glob in `SIMPLE_ENGLISH_LINT_EXCLUDE`.
+
+A symlink does not defeat a skip. The check tests the absolute path in two forms, as written and with the symlinks resolved. A match on either form is enough.
+
+`SIMPLE_ENGLISH_LINT_EXCLUDE` holds glob patterns, separated by the path separator of the platform (`:` on Linux and macOS, `;` on Windows). In a pattern, `*` also matches `/`. The check expands a leading `~` to your home directory.
+
+```bash
+export SIMPLE_ENGLISH_LINT_EXCLUDE="$HOME/notes/*:*/CHANGELOG.md"
+```
+
+To turn the file check off, set the variable to `*`. The `Stop` reply check stays on.

--- a/src/hooks/lint_hook.py
+++ b/src/hooks/lint_hook.py
@@ -4,12 +4,18 @@
 PostToolUse (Write|Edit on a .md file): lint the file with evals/ste_lint.py
 and, when it has violations, print a short summary to stderr and exit 2 so
 the model sees it. Exit 2 on PostToolUse is advisory: the tool already ran.
+Agent-internal Markdown, such as memory files under the Claude configuration
+directory, is skipped. The writing rules do not govern it, and a summary of
+its violations only spends tokens. Set SIMPLE_ENGLISH_LINT_EXCLUDE to skip
+more paths.
 
 Stop: read `last_assistant_message`, check the reply register (answer first,
 5 sentences or fewer, no slop words), and return a systemMessage only when
 the reply breaks it. Always exit 0, so the session never loops.
 """
+import fnmatch
 import json
+import os
 import pathlib
 import re
 import sys
@@ -19,6 +25,7 @@ ROOT = HERE.parent.parent
 sys.path.insert(0, str(ROOT / "evals"))
 
 MAX_REPLY_SENTENCES = 5
+CLAUDE_DIR = ".claude"
 OPENERS = re.compile(r"^\s*(certainly|great question|you're absolutely right|sure[,!]|absolutely[,!])", re.I)
 CLOSERS = re.compile(r"(i hope this helps|let me know if|feel free to)", re.I)
 
@@ -36,15 +43,46 @@ def strip_code(text):
     return re.sub(r"`[^`]*`", " ", text)
 
 
+def absolute(path, cwd=None):
+    """Make the path absolute. The harness can send it relative to the session directory."""
+    return pathlib.Path(cwd or ".", pathlib.Path(path).expanduser()).absolute()
+
+
+def variants(path):
+    """The path as written and the path with symlinks resolved. An exclusion matches either form.
+
+    A symlink hides a directory name in both directions. `notes.md` can point into `.claude`,
+    and `.claude` itself can point at a dotfiles repository. Both forms must miss for the
+    file to reach the linter.
+    """
+    return {pathlib.Path(os.path.normpath(path)), path.resolve()}
+
+
+def excluded(target):
+    """True for agent-internal Markdown and for the paths the user excludes."""
+    config_dirs = variants(absolute(os.environ.get("CLAUDE_CONFIG_DIR") or f"~/{CLAUDE_DIR}"))
+    raw = os.environ.get("SIMPLE_ENGLISH_LINT_EXCLUDE", "").split(os.pathsep)
+    patterns = [os.path.expanduser(p) for p in raw if p]
+    for form in variants(target):
+        if CLAUDE_DIR in form.parts or any(form.is_relative_to(d) for d in config_dirs):
+            return True
+        if any(fnmatch.fnmatch(str(form), p) for p in patterns):
+            return True
+    return False
+
+
 def post_tool_use(event):
     path = (event.get("tool_input") or {}).get("file_path", "")
     if not path.endswith(".md"):
+        return 0
+    target = absolute(path, event.get("cwd"))
+    if excluded(target):
         return 0
     lint = load_linter()
     if lint is None:
         return 0
     try:
-        text = pathlib.Path(path).read_text(encoding="utf-8")
+        text = target.read_text(encoding="utf-8")
     except OSError:
         return 0
     report = lint.lint(text, "descriptive")
@@ -53,7 +91,7 @@ def post_tool_use(event):
         return 0
     summary = ", ".join(f"{k} {v}" for k, v in hits.items())
     sys.stderr.write(
-        f"simple-english: {pathlib.Path(path).name} has {report['violations_total']} STE violations "
+        f"simple-english: {target.name} has {report['violations_total']} STE violations "
         f"({summary}). Run the self-check in SKILL.md before you deliver.\n"
     )
     return 2

--- a/src/hooks/test_lint_hook.py
+++ b/src/hooks/test_lint_hook.py
@@ -1,15 +1,26 @@
-import json, pathlib, subprocess, sys, tempfile
+import json, os, pathlib, subprocess, sys, tempfile
 HERE = pathlib.Path(__file__).resolve().parent
 HOOK = HERE / "lint_hook.py"
+CLEAN = {"CLAUDE_CONFIG_DIR": "/nonexistent/claude-config", "SIMPLE_ENGLISH_LINT_EXCLUDE": ""}
+SLOP = "You should simply leverage the robust tool, making it seamless.\n"
 
-def run(event):
-    r = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(event), capture_output=True, text=True)
+def run(event, env=None):
+    r = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(event), capture_output=True, text=True,
+                       env={**os.environ, **CLEAN, **(env or {})})
     return r.returncode, r.stdout, r.stderr
 
+def write_slop(directory, name="notes.md"):
+    path = pathlib.Path(directory, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(SLOP, encoding="utf-8")
+    return str(path)
+
+def post(path, **event):
+    return {"hook_event_name": "PostToolUse", "tool_name": "Write", "tool_input": {"file_path": path}, **event}
+
 def test_post_tool_use_flags_a_slop_markdown_file():
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
-        f.write("You should simply leverage the robust tool, making it seamless.\n"); path = f.name
-    code, out, err = run({"hook_event_name": "PostToolUse", "tool_name": "Write", "tool_input": {"file_path": path}})
+    with tempfile.TemporaryDirectory() as d:
+        code, out, err = run(post(write_slop(d)))
     assert code == 2 and "STE violations" in err, (code, err)
 
 def test_post_tool_use_ignores_clean_file_and_non_markdown():
@@ -17,6 +28,54 @@ def test_post_tool_use_ignores_clean_file_and_non_markdown():
         f.write("Run the migration. Then restart the service.\n"); path = f.name
     assert run({"hook_event_name": "PostToolUse", "tool_input": {"file_path": path}})[0] == 0
     assert run({"hook_event_name": "PostToolUse", "tool_input": {"file_path": "/tmp/x.py"}})[0] == 0
+
+def test_post_tool_use_skips_the_claude_config_dir():
+    with tempfile.TemporaryDirectory() as d:
+        path = write_slop(pathlib.Path(d, "projects", "repo", "memory"), "MEMORY.md")
+        assert run(post(path))[0] == 2, "a memory file outside any config dir still lints"
+        assert run(post(path), env={"CLAUDE_CONFIG_DIR": d})[0] == 0
+
+def test_post_tool_use_skips_a_dot_claude_directory():
+    with tempfile.TemporaryDirectory() as d:
+        assert run(post(write_slop(pathlib.Path(d, ".claude", "agent-memory", "reviewer"), "MEMORY.md")))[0] == 0
+
+def test_post_tool_use_honours_the_exclude_globs():
+    with tempfile.TemporaryDirectory() as d:
+        path = write_slop(d)
+        assert run(post(path))[0] == 2
+        globs = os.pathsep.join(["~/no-such-file.md", f"{d}/*.md"])
+        assert run(post(path), env={"SIMPLE_ENGLISH_LINT_EXCLUDE": globs})[0] == 0
+
+def test_post_tool_use_resolves_a_relative_path_against_the_event_cwd():
+    with tempfile.TemporaryDirectory() as d:
+        write_slop(d)
+        assert run(post("notes.md", cwd=d))[0] == 2
+
+def test_post_tool_use_lints_a_path_that_escapes_a_dot_claude_directory():
+    with tempfile.TemporaryDirectory() as d:
+        write_slop(d)
+        pathlib.Path(d, ".claude").mkdir()
+        assert run(post(str(pathlib.Path(d, ".claude", "..", "notes.md"))))[0] == 2
+
+def test_post_tool_use_skips_a_symlink_into_a_dot_claude_directory():
+    with tempfile.TemporaryDirectory() as d:
+        link = pathlib.Path(d, "notes.md")
+        link.symlink_to(write_slop(pathlib.Path(d, ".claude"), "MEMORY.md"))
+        assert run(post(str(link)))[0] == 0
+
+def test_post_tool_use_skips_a_symlinked_dot_claude_directory():
+    with tempfile.TemporaryDirectory() as d:
+        write_slop(pathlib.Path(d, "dotfiles"), "MEMORY.md")
+        pathlib.Path(d, ".claude").symlink_to(pathlib.Path(d, "dotfiles"))
+        assert run(post(str(pathlib.Path(d, ".claude", "MEMORY.md"))))[0] == 0
+
+def test_post_tool_use_matches_a_glob_through_a_symlinked_directory():
+    with tempfile.TemporaryDirectory() as d:
+        write_slop(pathlib.Path(d, "store"))
+        pathlib.Path(d, "notes").symlink_to(pathlib.Path(d, "store"))
+        path = str(pathlib.Path(d, "notes", "notes.md"))
+        assert run(post(path))[0] == 2
+        assert run(post(path), env={"SIMPLE_ENGLISH_LINT_EXCLUDE": f"{d}/notes/*"})[0] == 0
 
 def test_stop_flags_long_slop_reply_and_never_blocks():
     long = "Great question! " + "This is a robust sentence. " * 7 + "I hope this helps!"


### PR DESCRIPTION
The PostToolUse check linted Claude's own memory files, and every other Markdown file under the configuration directory. Each edit spent tokens on a violation summary for text that the writing rules do not govern.

The check now skips the Claude configuration directory (CLAUDE_CONFIG_DIR, default ~/.claude), any path with a .claude component, and the globs in the new SIMPLE_ENGLISH_LINT_EXCLUDE variable. It tests the absolute path in two forms, as written and with the symlinks resolved, so a symlink in either direction cannot defeat a skip. It also resolves a relative file_path against the cwd of the hook event, instead of the working directory of the hook process.

Closes #27